### PR TITLE
Add `joyride.core` namespace w/ `*file*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes to Joyride
 
 ## [Unreleased]
 
+- [Add `joyride.core/*file*`](https://github.com/BetterThanTomorrow/joyride/issues/5)
 
 ## [0.0.2] - 2022-04-27
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -1,0 +1,31 @@
+# API
+
+In addition to `clojure.core`, `clojure.set`, `clojure.edn`, `clojure.string`,
+`clojure.walk`, `clojure.data`, Joyride exposes
+the following namespaces:
+
+## Joyride
+
+### `joyride.core`
+
+- `*file*`: dynamic var representing the currently executing file.
+
+NB: While using `*file*` bare works, this will probably stop working soon. Always use it from `joyride.core`, e.g.:
+
+```clojure
+(ns your-awesome-script
+  (:require [joyride.core :refer [*file*]]
+            ...))
+```
+
+## Promesa
+
+See [promesa docs](https://cljdoc.org/d/funcool/promesa/6.0.2/doc/user-guide).
+
+### `promesa.core`
+
+- `let`, `do!`
+
+## Possibly coming additions
+
+We want to add `clojure.test` and `clojure.pprint` as well in the near future. How near/if depends on things like how much time we can spend on it, and how easy/hard it will be to port this over from [nbb](https://github.com/babashka/nbb).

--- a/doc/api.md
+++ b/doc/api.md
@@ -24,7 +24,7 @@ See [promesa docs](https://cljdoc.org/d/funcool/promesa/6.0.2/doc/user-guide).
 
 ### `promesa.core`
 
-- `let`, `do!`
+`p/->>`, `p/->`, `p/all`, `p/any`, `p/catch`, `p/chain`, `p/create`, `p/deferred`, `p/delay`, `p/do`, `p/do`, `p/done`, `p/finally`, `p/let`, `p/map`, `p/mapcat`, `p/pending`, `p/promise`, `p/promise`, `p/race`, `p/rejected`, `p/rejected`, `p/resolved`, `p/resolved`, `p/run`, `p/then`, `p/thenable`, `p/with`, and `p/wrap`
 
 ## Possibly coming additions
 

--- a/examples/.joyride/scripts/ignore_form.cljs
+++ b/examples/.joyride/scripts/ignore_form.cljs
@@ -1,8 +1,17 @@
 (ns ignore-form
   (:require ["vscode" :as vsode]
             [promesa.core :as p]
-            [joyride.core :as j]
             [z-joylib.editor-utils :as eu]))
+
+(def f *file*)
+(defonce run-main? true)
+
+(comment
+  ;; Loading this in the REPL w/o evaluating `main`:
+  (defonce run-main? false)  ; <- First evaluate this
+  (ns-unmap *ns* 'run-main?) ; <- Evaluate this when you are done
+                             ;    or want to test-run the script
+  )
 
 (defn main []
   (p/let [editor ^js vscode/window.activeTextEditor
@@ -12,9 +21,8 @@
     (aset editor "selection" original-selection)
     (p/do! (eu/insert-text!+ "#_" editor insert-position))))
 
-(when j/*file*
+(when run-main?
   (main))
 
-(comment  
-  (main)
-  )
+(comment
+  (main))

--- a/examples/.joyride/scripts/ignore_form.cljs
+++ b/examples/.joyride/scripts/ignore_form.cljs
@@ -1,17 +1,8 @@
 (ns ignore-form
   (:require ["vscode" :as vsode]
             [promesa.core :as p]
+            [joyride.core :as j]
             [z-joylib.editor-utils :as eu]))
-
-(def f *file*)
-(defonce run-main? true)
-
-(comment
-  ;; Loading this in the REPL w/o evaluating `main`:
-  (defonce run-main? false)  ; <- First evaluate this
-  (ns-unmap *ns* 'run-main?) ; <- Evaluate this when you are done
-                             ;    or want to test-run the script
-  )
 
 (defn main []
   (p/let [editor ^js vscode/window.activeTextEditor
@@ -21,7 +12,7 @@
     (aset editor "selection" original-selection)
     (p/do! (eu/insert-text!+ "#_" editor insert-position))))
 
-(when run-main?
+(when j/*file*
   (main))
 
 (comment  

--- a/examples/.joyride/scripts/ignore_form.cljs
+++ b/examples/.joyride/scripts/ignore_form.cljs
@@ -24,5 +24,6 @@
 (when run-main?
   (main))
 
-(comment
-  (main))
+(comment  
+  (main)
+  )

--- a/src/main/joyride/extension.cljs
+++ b/src/main/joyride/extension.cljs
@@ -3,8 +3,8 @@
    ["path" :as path]
    ["vscode" :as vscode]
    [joyride.nrepl :as nrepl]
-   [joyride.sci :as sci]
-   [sci.core]
+   [joyride.sci :as jsci]
+   [sci.core :as sci]
    [joyride.scripts-menu :refer [show-workspace-scripts-menu+]]
    [joyride.settings :refer [workspace-scripts-path]]
    [joyride.utils :refer [vscode-read-uri+ info]]
@@ -33,7 +33,7 @@
 (defn eval-query []
   (p/let [input (vscode/window.showInputBox #js {:placeHolder "(require '[\"path\" :as path]) (path/resolve \".\")"
                                                  :prompt "Type one or more expressions to evaluate"})
-          res (sci/eval-string input)]
+          res (jsci/eval-string input)]
     (info "The result:" res)))
 
 (defn run-script [& _script]
@@ -53,8 +53,8 @@
    (-> (p/let [abs-path (path/join vscode/workspace.rootPath workspace-scripts-path script-path)
                script-uri (vscode/Uri.file abs-path)
                code (vscode-read-uri+ script-uri)]
-         (sci.core/with-bindings {sci.core/file abs-path}
-           (sci/eval-string code)))
+         (sci/with-bindings {sci/file abs-path}
+           (jsci/eval-string code)))
        (p/handle (fn [result error]
                    (if error
                      (do

--- a/src/main/joyride/extension.cljs
+++ b/src/main/joyride/extension.cljs
@@ -4,6 +4,7 @@
    ["vscode" :as vscode]
    [joyride.nrepl :as nrepl]
    [joyride.sci :as sci]
+   [sci.core]
    [joyride.scripts-menu :refer [show-workspace-scripts-menu+]]
    [joyride.settings :refer [workspace-scripts-path]]
    [joyride.utils :refer [vscode-read-uri+ info]]
@@ -52,7 +53,8 @@
    (-> (p/let [abs-path (path/join vscode/workspace.rootPath workspace-scripts-path script-path)
                script-uri (vscode/Uri.file abs-path)
                code (vscode-read-uri+ script-uri)]
-         (sci/eval-string code))
+         (sci.core/with-bindings {sci.core/file abs-path}
+           (sci/eval-string code)))
        (p/handle (fn [result error]
                    (if error
                      (do

--- a/src/main/joyride/nrepl.cljs
+++ b/src/main/joyride/nrepl.cljs
@@ -109,12 +109,17 @@
       "classpath"
       (cp/split-classpath (cp/get-classpath))}))
 
-(defn handle-load-file [{:keys [file] :as request} send-fn]
-  (do-handle-eval (assoc request
-                         :code file
-                         :load-file? true
-                         :ns @sci/ns)
-                  send-fn))
+(defn handle-load-file [{:keys [file file-path] :as request} send-fn]
+  (def request request)
+  (comment (type request)
+           (keys request)
+           )
+  (sci/with-bindings {sci/file file-path}
+    (do-handle-eval (assoc request
+                           :code file
+                           :load-file? true
+                           :ns @sci/ns)
+                    send-fn)))
 
 
 ;;;; Completions, based on babashka.nrepl

--- a/src/main/joyride/sci.cljs
+++ b/src/main/joyride/sci.cljs
@@ -19,7 +19,8 @@
 (def !ctx (volatile!
            (sci/init {:classes {'js goog/global
                                 :allow :all}
-                      :namespaces (:namespaces pconfig/config)
+                      :namespaces (merge (:namespaces pconfig/config)
+                                         {'joyride.core {'*file* sci/file}})
                       :load-fn (fn [{:keys [namespace opts]}]
                                  (cond
                                    (symbol? namespace)

--- a/src/main/joyride/sci.cljs
+++ b/src/main/joyride/sci.cljs
@@ -19,8 +19,8 @@
 (def !ctx (volatile!
            (sci/init {:classes {'js goog/global
                                 :allow :all}
-                      :namespaces (merge (:namespaces pconfig/config)
-                                         {'joyride.core {'*file* sci/file}})
+                      :namespaces (assoc (:namespaces pconfig/config)
+                                         'joyride.core {'*file* sci/file})
                       :load-fn (fn [{:keys [namespace opts]}]
                                  (cond
                                    (symbol? namespace)


### PR DESCRIPTION
Fixes: #5

It took an embarrassing amount of time for me to figure this out. 😄 But now I think I am starting to get more of it and am glad I didn't give up and tossed it back to you, @borkdude.

These are the minimal changes. I choose to start like this to make the change easier to give and receive feedback on.

I would like to do rename `joyride.sci` to `joyride.core`, because it gets a bit of a mind fuck remembering which `sci` is which.

Also, I updated the example to use this new facility. And then we are now running into the same problem as Calva has with what is on `master` and what is published. The example won't really work with v0.0.2. In Calva we solve it by having a `dev` branch where we direct PRs and accumulate changes, We then merge to the default branch when we release. It works, but causes some friction.