### PR TITLE
More proper run code command and fix dev reloadability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Joyride
 ## [Unreleased]
 
 - [Add `joyride.core/*file*`](https://github.com/BetterThanTomorrow/joyride/issues/5)
+- Change name of command *Run Script* -> *Run Clojure Code*
 
 ## [0.0.2] - 2022-04-27
 

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
   "contributes": {
     "commands": [
       {
-        "command": "joyride.runScript",
-        "title": "Run Script",
+        "command": "joyride.runCode",
+        "title": "Run Clojure Code",
         "category": "Joyride"
       },
       {

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -7,4 +7,6 @@
               :compiler-options {:infer-externs :auto}
               :output-dir "out/js"
               :output-to "out/joyride.js"
-              :exports {:activate joyride.extension/activate}}}}
+              :exports {:activate joyride.extension/activate}
+              :devtools {:before-load-async joyride.extension/before
+                         :after-load joyride.extension/after}}}}


### PR DESCRIPTION
The command for running a piece of code was named `runScript`, which implied it worked similar to the runWorkspaceScript command, which it doesn't. It prompted for the user to input code, and disregarded any argument. The result of evaluating the code was then alerted, causing noice in the UI.

The command is now renamed. to `runCode` and will evaluate the argument, if handed one, as code. And without any argument it will prompt for code, as before. The results are printed in the Joyride output channel, where it can be copied to the clipboard, or whatever.

While doing this work, I noticed I was losing the output channel reference when I saved the file. Which was because the `!db` item was `def`ed instead of `defonce`ed. I decided to put in a proper lifecycle managament with shadow-cljs `:before` and `:after` hooks. And I also wanted to be able to ”reactivate” the extension w/o restart so I fixed that too, and made it happen on shadow-cljs reload.