### PR TITLE
Extend example to also be able to un-ignore forms

### DIFF
--- a/examples/.joyride/scripts/ignore_form.cljs
+++ b/examples/.joyride/scripts/ignore_form.cljs
@@ -17,9 +17,14 @@
   (p/let [editor ^js vscode/window.activeTextEditor
           original-selection (eu/current-selection)
           _ (vscode/commands.executeCommand "paredit.backwardUpSexp")
-          insert-position (.-active (eu/current-selection))]
+          insert-position (.-active (eu/current-selection))
+          insert-position-2 (.with insert-position (.-line insert-position) (max 0 (- (.-character insert-position) 2)))
+          range-before-insert-position (.with (eu/current-selection) insert-position-2 insert-position)
+          text-before-insert-position (.getText (.-document editor) range-before-insert-position)]
     (aset editor "selection" original-selection)
-    (p/do! (eu/insert-text!+ "#_" editor insert-position))))
+    (if (= "#_" text-before-insert-position)
+      (p/do! (eu/delete-range! editor range-before-insert-position))
+      (p/do! (eu/insert-text!+ "#_" editor insert-position)))))
 
 (when run-main?
   (main))

--- a/examples/.joyride/scripts/z_joylib/editor_utils.cljs
+++ b/examples/.joyride/scripts/z_joylib/editor_utils.cljs
@@ -23,6 +23,15 @@
        (p/catch (fn [e]
                   (js/console.error e))))))
 
+(defn delete-range!
+  [^js editor ^js range]
+  (-> (p/do (.edit editor
+                   (fn [^js builder]
+                     (.delete builder range))
+                   #js {:undoStopBefore true :undoStopAfter false}))
+      (p/catch (fn [e]
+                 (js/console.error e)))))
+
 (comment
   (def a-selection (current-selection))
   (aset vscode/window.activeTextEditor "selection" a-selection)


### PR DESCRIPTION
This is so cool @PEZ and @borkdude :) I extended the ignore-form example so that it can also un-ignore forms.

FYI, I'm using this keybinding config in VSCode (for macOS):

```json
{
  "key": "cmd+/",
  "command": "joyride.runWorkspaceScript",
  "args": "ignore_form.cljs",
  "when": "!editorHasSelection && editorTextFocus && !editorReadOnly && editorLangId =~ /clojure|scheme|lisp/"
}
```

This way, when I have nothing selected, it will use the (un)ignore with `#_`, and when I do have a selection it will use the standard `;;` for comment/uncomment.
