### PR TITLE
Add get-extension-context to joyride.core

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -17,9 +17,10 @@ the following namespaces:
 
 ### `joyride.core`
 
-- `*file*`: dynamic var representing the currently executing file.
+- `*file*`: dynamic var representing the currently executing file
+- `get-extension-context`: function returning the Joyride [extension context](https://code.visualstudio.com/api/references/vscode-api#ExtensionContext) object
 
-NB: While using `*file*` bare works, this will probably stop working soon. Always use it from `joyride.core`, e.g.:
+NB: While using `*file*` bare works, it will probably stop working soon. Always use it from `joyride.core`, e.g.:
 
 ```clojure
 (ns your-awesome-script

--- a/examples/.joyride/scripts/joyride_api.cljs
+++ b/examples/.joyride/scripts/joyride_api.cljs
@@ -36,4 +36,7 @@
   (require '[joyride.core :as joyride])
   (-> (joyride/get-extension-context)
       .-extension
-      .-exports))
+      .-exports)
+  (require '[clojure.repl :refer [doc]])
+  (doc joyride/get-extension-context)
+  )

--- a/examples/.joyride/scripts/joyride_api.cljs
+++ b/examples/.joyride/scripts/joyride_api.cljs
@@ -2,9 +2,8 @@
   (:require ["vscode" :as vscode]
             [promesa.core :as p]))
 
-(def joyride (vscode/extensions.getExtension "betterthantomorrow.joyride"))
-
-(def joyApi (.-exports joyride))
+(def joyrideExt (vscode/extensions.getExtension "betterthantomorrow.joyride"))
+(def joyApi (.-exports joyrideExt))
 
 (comment
   ;; Starting the nREPL server
@@ -20,14 +19,21 @@
   ;; Getting contexts
   (.getContextValue joyApi "joyride.isNReplServerRunning")
   
-  ;; Non-Joyride context keys returns nil
+  ;; Non-Joyride context keys returns `nil`
   (.getContextValue joyApi "foo.bar")
 
   ;; NB: Use the extension instance for this!
   (.getContextValue joyApi "joyride.isActive")
   ;; Like so:
-  (.-isActive joyride)
+  (.-isActive joyrideExt)
   ;; (Not that it matters, you can't deactivate Joyride,
   ;;  and you can't talk to a deactivated REPL server.)
   )
 
+(comment
+  ;; Joyride scripts can also reach the Joyride extension
+  ;; through `joyride.core`
+  (require '[joyride.core :as joyride])
+  (-> (joyride/get-extension-context)
+      .-extension
+      .-exports))

--- a/playground/hello-joyride/.joyride/scripts/hello.cljs
+++ b/playground/hello-joyride/.joyride/scripts/hello.cljs
@@ -2,7 +2,6 @@
   (:require ["vscode" :as vscode]
             [joyride.core :as j]))
 
-#_(in-ns 'hello)
 (def foo :foo)
 (def f j/*file*)
 
@@ -10,7 +9,11 @@
   (vscode/window.showInformationMessage "Joyride says hello from a selection! 👋"))
 
 (comment
-  j/*file*)
+  j/*file*
+
+  (def ext-ctx (joyride/get-extension-context))
+  (.-extensionPath ext-ctx)
+  )
 
 (when :invoked-file=*file*
   (main))

--- a/src/main/joyride/extension.cljs
+++ b/src/main/joyride/extension.cljs
@@ -118,6 +118,7 @@
     (reset! !db {:output-channel (vscode/window.createOutputChannel "Joyride")
                  :extension-context context
                  :disposables []})
+    (vreset! jsci/!extension-context context)
     (say "🟢 Joyride VS Code with Clojure. 🚗"))
   (let [{:keys [extension-context]} @!db]
     (register-command! extension-context "joyride.runCode" #'run-code)

--- a/src/main/joyride/sci.cljs
+++ b/src/main/joyride/sci.cljs
@@ -12,6 +12,14 @@
 
 (def !extension-context (volatile! nil))
 
+(defn get-extension-context
+  "Returns the Joyride extension context object.
+   See: https://code.visualstudio.com/api/references/vscode-api#ExtensionContext"
+  []
+  @!extension-context)
+
+(def joyride-ns (sci/create-ns 'joyride.core nil))
+
 (defn ns->path [namespace]
   (-> (str namespace)
       (munge)
@@ -23,8 +31,7 @@
                                 :allow :all}
                       :namespaces (assoc (:namespaces pconfig/config)
                                          'joyride.core {'*file* sci/file
-                                                        'get-extension-context (fn []
-                                                                                 @!extension-context)})
+                                                        'get-extension-context (sci/copy-var get-extension-context joyride-ns)})
                       :load-fn (fn [{:keys [namespace opts]}]
                                  (cond
                                    (symbol? namespace)

--- a/src/main/joyride/sci.cljs
+++ b/src/main/joyride/sci.cljs
@@ -10,6 +10,8 @@
 
 (sci/alter-var-root sci/print-fn (constantly *print-fn*))
 
+(def !extension-context (volatile! nil))
+
 (defn ns->path [namespace]
   (-> (str namespace)
       (munge)
@@ -20,7 +22,9 @@
            (sci/init {:classes {'js goog/global
                                 :allow :all}
                       :namespaces (assoc (:namespaces pconfig/config)
-                                         'joyride.core {'*file* sci/file})
+                                         'joyride.core {'*file* sci/file
+                                                        'get-extension-context (fn []
+                                                                                 @!extension-context)})
                       :load-fn (fn [{:keys [namespace opts]}]
                                  (cond
                                    (symbol? namespace)


### PR DESCRIPTION
Adds a function to `joyride.core` for getting the Joyride extension context.

Fixes #33