### PR TITLE
Add `joyride.core/get-invoked-script`

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -29,6 +29,11 @@ the following namespaces:
 #### `joyride.core`
 
 - `*file*`: dynamic var representing the currently executing file
+- `get-invoked-script`: function returning the absolute path of the invoked script when running as a script. Otherwise returns `nil`. Together with `*file*` this can be used to create a guard that avoids running certain code when you load a file in the REPL:
+  ```clojure
+  (when (= (joyride/get-invoked-script) joyride/*file*)
+    (main))
+  ```
 - `get-extension-context`: function returning the Joyride [extension context](https://code.visualstudio.com/api/references/vscode-api#ExtensionContext) object
 
 NB: While using `*file*` bare works, it will probably stop working soon. Always use it from `joyride.core`, e.g.:

--- a/examples/.joyride/scripts/activate.cljs
+++ b/examples/.joyride/scripts/activate.cljs
@@ -1,9 +1,6 @@
 (ns activate
   (:require [joyride.core :as joyride]
-            ["vscode" :as vscode]
-            [promesa.core :as p]))
-
-(println "Hello World, from Workspace activate.cljs script")
+            ["vscode" :as vscode]))
 
 (defonce !db (atom {:disposables []}))
 
@@ -26,6 +23,7 @@
       (.push disposable)))
 
 (defn- my-main []
+  (println "Hello World, from Workspace activate.cljs script")
   (clear-disposables!)
   (push-disposable
    ;; It might surprise you to see how often and when this happens,
@@ -37,5 +35,5 @@
                "document opened:" 
                (.-fileName doc))))))
 
-(when true
+(when (= (joyride/get-invoked-script) joyride/*file*)
   (my-main))

--- a/examples/.joyride/scripts/fontsize.cljs
+++ b/examples/.joyride/scripts/fontsize.cljs
@@ -1,13 +1,13 @@
 (ns fontsize
-  (:require ["vscode" :as vscode]))
+  (:require ["vscode" :as vscode]
+            [joyride.core :as joyride]))
 
 (defn set-global-fontsize [pts]
   (-> (vscode/workspace.getConfiguration)
       (.update "editor.fontSize" pts true))
   nil)
 
-(comment
-  (set-global-fontsize 12)
-  )
+(when (= (joyride/get-invoked-script) joyride/*file*)
+  (set-global-fontsize 12))
 
 ;; live demo here: https://twitter.com/borkdude/status/1519709769157775360

--- a/examples/.joyride/scripts/ignore_form.cljs
+++ b/examples/.joyride/scripts/ignore_form.cljs
@@ -1,17 +1,8 @@
 (ns ignore-form
   (:require ["vscode" :as vsode]
+            [joyride.core :as joyride]
             [promesa.core :as p]
             [z-joylib.editor-utils :as eu]))
-
-(def f *file*)
-(defonce run-main? true)
-
-(comment
-  ;; Loading this in the REPL w/o evaluating `main`:
-  (defonce run-main? false)  ; <- First evaluate this
-  (ns-unmap *ns* 'run-main?) ; <- Evaluate this when you are done
-                             ;    or want to test-run the script
-  )
 
 (defn main []
   (p/let [editor ^js vscode/window.activeTextEditor
@@ -26,9 +17,5 @@
       (p/do! (eu/delete-range! editor range-before-insert-position))
       (p/do! (eu/insert-text!+ "#_" editor insert-position)))))
 
-(when run-main?
+(when (= (joyride/get-invoked-script) joyride/*file*)
   (main))
-
-(comment  
-  (main)
-  )

--- a/examples/.joyride/scripts/open_document.cljs
+++ b/examples/.joyride/scripts/open_document.cljs
@@ -1,6 +1,7 @@
 (ns open-document
-  (:require [promesa.core :as p]
-            ["vscode" :as vscode]))
+  (:require ["vscode" :as vscode]
+            [joyride.core :as joyride]
+            [promesa.core :as p]))
 
 (defn show-random-example []
   (p/let [examples (vscode/workspace.findFiles ".joyride/scripts/**/*.cljs")
@@ -9,9 +10,13 @@
           (vscode/window.showTextDocument
            #js {:preview false, :preserveFocus false}))))
 
-(p/-> (vscode/window.showInformationMessage "Welcome to the Joyride examples workspace. Want to look at a random example?" "Yes" "No")
-      (p/then (fn [choice]
-                (case choice
-                  "Yes" (show-random-example)
-                  "No" :no
-                  :none))))
+(defn my-main []
+  (p/-> (vscode/window.showInformationMessage "Welcome to the Joyride examples workspace. Want to look at a random example?" "Yes" "No")
+        (p/then (fn [choice]
+                  (case choice
+                    "Yes" (show-random-example)
+                    "No" :no
+                    :none)))))
+
+(when (= (joyride/get-invoked-script) joyride/*file*)
+  (my-main))

--- a/examples/.joyride/scripts/terminal.cljs
+++ b/examples/.joyride/scripts/terminal.cljs
@@ -1,19 +1,20 @@
 (ns terminal
-  (:require ["os" :as os]
-            ["path" :as path]
-            ["vscode" :as vscode]))
+  (:require ["vscode" :as vscode]
+            [joyride.core :as joyride]))
 
-;; start a terminal called nbb in $HOME/dev/nbb
-(def terminal
-  (vscode/window.createTerminal
-   #js {:name "nbb"
-        :cwd (path/join (os/homedir) "dev" "nbb")}))
+(defn main []
+   ;; start a terminal called nbb in $HOME/dev/nbb
+  (let [terminal (vscode/window.createTerminal
+                  #js {:name "nbb"})]
+    
+    ;; make it visible
+    (.show terminal true)
 
-;; make it visible
-(terminal.show true)
+    ;; send an initial command to it
+    (.sendText terminal "npx nbb")))
 
-;; send an initial command to it
-(terminal.sendText "bb dev")
+(when (= (joyride/get-invoked-script) joyride/*file*)
+  (main))
 
 ;; see live demo here:
 ;; https://twitter.com/borkdude/status/1519304323703971841

--- a/examples/.joyride/scripts/webview/example.cljs
+++ b/examples/.joyride/scripts/webview/example.cljs
@@ -1,18 +1,22 @@
 (ns webview.example
-  (:require ["fs" :as fs]
-            ["path" :as path]
-            ["vscode" :as vscode]))
+  (:require ["path" :as path]
+            ["vscode" :as vscode]
+            [joyride.core :as joyride]
+            [promesa.core :as p]))
 
-(def panel
-  (vscode/window.createWebviewPanel
-   "My webview!" "Scittle"
-   vscode/ViewColumn.One
-   #js {:enableScripts true}))
+(defn main []
+  (p/let [panel (vscode/window.createWebviewPanel
+                 "My webview!" "Scittle"
+                 vscode/ViewColumn.One
+                 #js {:enableScripts true})
+          uri (vscode/Uri.file (path/join vscode/workspace.rootPath
+                                          ".joyride" "scripts" "webview"
+                                          "page.html"))
+          data (vscode/workspace.fs.readFile uri)
+          html (.decode (js/TextDecoder. "utf-8") data)]
+    (set! (.. panel -webview -html) (str html))))
 
-(def html (fs/readFileSync (path/join vscode/workspace.rootPath
-                                      ".joyride" "scripts" "webview"
-                                      "page.html")))
-
-(set! (.. panel -webview -html) (str html))
+(when (= (joyride/get-invoked-script) joyride/*file*)
+  (main))
 
 ;; live demo here: https://twitter.com/borkdude/status/1519607386218053632

--- a/src/main/joyride/extension.cljs
+++ b/src/main/joyride/extension.cljs
@@ -51,9 +51,11 @@
    (-> (p/let [abs-path (path/join base-path scripts-path script-path)
                script-uri (vscode/Uri.file abs-path)
                code (vscode-read-uri+ script-uri)]
+         (swap! db/!app-db assoc :invoked-script abs-path)
          (sci/with-bindings {sci/file abs-path}
            (jsci/eval-string code)))
        (p/handle (fn [result error]
+                   (swap! db/!app-db assoc :invoked-script nil)
                    (if error
                      (do
                        (utils/say-error (str title " Failed: " script-path " " (.-message error)))

--- a/src/main/joyride/sci.cljs
+++ b/src/main/joyride/sci.cljs
@@ -11,13 +11,19 @@
 
 (sci/alter-var-root sci/print-fn (constantly *print-fn*))
 
+(def joyride-ns (sci/create-ns 'joyride.core nil))
+
 (defn get-extension-context
   "Returns the Joyride extension context object.
    See: https://code.visualstudio.com/api/references/vscode-api#ExtensionContext"
   []
   (:extension-context @db/!app-db))
 
-(def joyride-ns (sci/create-ns 'joyride.core nil))
+(defn get-invoked-script
+  "Returns the absolute path of theinvoked script when the evaluation is made
+   through *Run Script*, otherwise returns `nil`."
+  []
+  (:invoked-script @db/!app-db))
 
 (defn ns->path [namespace]
   (-> (str namespace)
@@ -30,7 +36,8 @@
                                 :allow :all}
                       :namespaces (assoc (:namespaces pconfig/config)
                                          'joyride.core {'*file* sci/file
-                                                        'get-extension-context (sci/copy-var get-extension-context joyride-ns)})
+                                                        'get-extension-context (sci/copy-var get-extension-context joyride-ns)
+                                                        'get-invoked-script (sci/copy-var get-invoked-script joyride-ns)})
                       :load-fn (fn [{:keys [namespace opts]}]
                                  (cond
                                    (symbol? namespace)


### PR DESCRIPTION
Adds a function `get-invoked-script` to `joyride.core` that will be set when a script is run, but not otherwise.

Docs and examples updated accordingly.

Fixes #4