### PR TITLE
Add output channel access API

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,12 +103,16 @@ See the [examples](./examples) for examples including:
 * Calva Structural Editing enhancements
 * Opening and showing project files
 * Workspace activation script
+* The Joyride Extension API
+* The `joyride.core` namespace
 
 ## Support and feedback
 
 You'll find us in the `#joyride` channel on the [Clojurians Slack](http://clojurians.net)
 
 ## News
+
+* Show HN: https://news.ycombinator.com/item?id=31203024#31206003
 
 ### Twitter
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -29,6 +29,11 @@ the following namespaces:
 #### `joyride.core`
 
 - `*file*`: dynamic var representing the currently executing file
+- `get-invoked-script`: function returning the absolute path of the invoked script when running as a script. Otherwise returns `nil`. Together with `*file*` this can be used to create a guard that avoids running certain code when you load a file in the REPL:
+  ```clojure
+  (when (= (joyride/get-invoked-script) joyride/*file*)
+    (main))
+  ```
 - `get-extension-context`: function returning the Joyride [extension context](https://code.visualstudio.com/api/references/vscode-api#ExtensionContext) object
 
 NB: While using `*file*` bare works, it will probably stop working soon. Always use it from `joyride.core`, e.g.:

--- a/doc/api.md
+++ b/doc/api.md
@@ -7,6 +7,8 @@ The Joyride API consist of:
    * Included clojure library namespaces
 1. The Joyride *Extension API*
 
+Give the [joyride_api.cljs](../examples/.joyride/scripts/joyride_api.cljs) example a spin, why don't ya!
+
 Please note that Joyride's *Extension API* is also available to *Joyride scripts*.
 
 ## Scripting API
@@ -28,27 +30,42 @@ the following namespaces:
 
 #### `joyride.core`
 
-- `*file*`: dynamic var representing the currently executing file
+- `*file*`: dynamic var holding the absolute path of file where the current evaluation is taking place
 - `get-invoked-script`: function returning the absolute path of the invoked script when running as a script. Otherwise returns `nil`. Together with `*file*` this can be used to create a guard that avoids running certain code when you load a file in the REPL:
   ```clojure
   (when (= (joyride/get-invoked-script) joyride/*file*)
     (main))
   ```
-- `get-extension-context`: function returning the Joyride [extension context](https://code.visualstudio.com/api/references/vscode-api#ExtensionContext) object
+- `get-extension-context`: function returning the Joyride [ExtensionContext](https://code.visualstudio.com/api/references/vscode-api#ExtensionContext) instance
+- `get-output-channel`: function returning the Joyride [OutputChannel](https://code.visualstudio.com/api/references/vscode-api#OutputChannel) instance
 
-NB: While using `*file*` bare works, it will probably stop working soon. Always use it from `joyride.core`, e.g.:
+Here's a snippet from the [joyride_api.cljs](../examples/.joyride/scripts/joyride_api.cljs) example.
 
 ```clojure
 (ns your-awesome-script
-  (:require [joyride.core :refer [*file*]]
-            ...))
+  (:require [joyride.core :as joyride]
+            ...)
+
+(doto (joyride/get-output-channel)
+  (.show true)
+  (.append "Writing to the ")
+  (.appendLine "Joyride output channel.")
+  (.appendLine (str "Joyride extension path: "
+                    (-> (joyride/get-extension-context)
+                        .-extension
+                        .-extensionPath)))
+  (.appendLine (str "joyride/*file*: " joyride/*file*))
+  (.appendLine (str "Invoked script: " (joyride/get-invoked-script)))
+  (.appendLine "🎉"))
 ```
+
+**NB**: Currently, using bar `*file*` works. But it will probably stop working soon. Always use it from `joyride.core`.
 
 #### promesa.core
 
 See [promesa docs](https://cljdoc.org/d/funcool/promesa/6.0.2/doc/user-guide).
 
-**``**: `p/->>`, `p/->`, `p/all`, `p/any`, `p/catch`, `p/chain`, `p/create`, `p/deferred`, `p/delay`, `p/do`, `p/do`, `p/done`, `p/finally`, `p/let`, `p/map`, `p/mapcat`, `p/pending`, `p/promise`, `p/promise`, `p/race`, `p/rejected`, `p/rejected`, `p/resolved`, `p/resolved`, `p/run`, `p/then`, `p/thenable`, `p/with`, and `p/wrap`
+**``**: `p/->>`, `p/->`, `p/all`, `p/any`, `p/catch`, `p/chain`, `p/create`, `p/deferred`, `p/delay`, `p/do`, `p/do!`, `p/done?`, `p/finally`, `p/let`, `p/map`, `p/mapcat`, `p/pending`, `p/promise`, `p/promise?`, `p/race`, `p/rejected`, `p/rejected?`, `p/resolved`, `p/resolved?`, `p/run!`, `p/then`, `p/thenable?`, `p/with`, and `p/wrap`
 
 ### Possibly coming additions
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -31,13 +31,13 @@ the following namespaces:
 #### `joyride.core`
 
 - `*file*`: dynamic var holding the absolute path of file where the current evaluation is taking place
-- `get-invoked-script`: function returning the absolute path of the invoked script when running as a script. Otherwise returns `nil`. Together with `*file*` this can be used to create a guard that avoids running certain code when you load a file in the REPL:
+- `invoked-script`: function returning the absolute path of the invoked script when running as a script. Otherwise returns `nil`. Together with `*file*` this can be used to create a guard that avoids running certain code when you load a file in the REPL:
   ```clojure
-  (when (= (joyride/get-invoked-script) joyride/*file*)
+  (when (= (joyride/invoked-script) joyride/*file*)
     (main))
   ```
-- `get-extension-context`: function returning the Joyride [ExtensionContext](https://code.visualstudio.com/api/references/vscode-api#ExtensionContext) instance
-- `get-output-channel`: function returning the Joyride [OutputChannel](https://code.visualstudio.com/api/references/vscode-api#OutputChannel) instance
+- `extension-context`: function returning the Joyride [ExtensionContext](https://code.visualstudio.com/api/references/vscode-api#ExtensionContext) instance
+- `output-channel`: function returning the Joyride [OutputChannel](https://code.visualstudio.com/api/references/vscode-api#OutputChannel) instance
 
 Here's a snippet from the [joyride_api.cljs](../examples/.joyride/scripts/joyride_api.cljs) example.
 
@@ -46,16 +46,16 @@ Here's a snippet from the [joyride_api.cljs](../examples/.joyride/scripts/joyrid
   (:require [joyride.core :as joyride]
             ...)
 
-(doto (joyride/get-output-channel)
+(doto (joyride/output-channel)
   (.show true)
   (.append "Writing to the ")
   (.appendLine "Joyride output channel.")
   (.appendLine (str "Joyride extension path: "
-                    (-> (joyride/get-extension-context)
+                    (-> (joyride/extension-context)
                         .-extension
                         .-extensionPath)))
   (.appendLine (str "joyride/*file*: " joyride/*file*))
-  (.appendLine (str "Invoked script: " (joyride/get-invoked-script)))
+  (.appendLine (str "Invoked script: " (joyride/invoked-script)))
   (.appendLine "🎉"))
 ```
 

--- a/examples/.joyride/scripts/activate.cljs
+++ b/examples/.joyride/scripts/activate.cljs
@@ -1,9 +1,6 @@
 (ns activate
   (:require [joyride.core :as joyride]
-            ["vscode" :as vscode]
-            [promesa.core :as p]))
-
-(println "Hello World, from Workspace activate.cljs script")
+            ["vscode" :as vscode]))
 
 (defonce !db (atom {:disposables []}))
 
@@ -26,6 +23,7 @@
       (.push disposable)))
 
 (defn- my-main []
+  (println "Hello World, from Workspace activate.cljs script")
   (clear-disposables!)
   (push-disposable
    ;; It might surprise you to see how often and when this happens,
@@ -37,5 +35,5 @@
                "document opened:" 
                (.-fileName doc))))))
 
-(when true
+(when (= (joyride/get-invoked-script) joyride/*file*)
   (my-main))

--- a/examples/.joyride/scripts/activate.cljs
+++ b/examples/.joyride/scripts/activate.cljs
@@ -18,7 +18,7 @@
 ;; Joyride extension is deactivated.
 (defn- push-disposable [disposable]
   (swap! !db update :disposables conj disposable)
-  (-> (joyride/get-extension-context)
+  (-> (joyride/extension-context)
       .-subscriptions
       (.push disposable)))
 
@@ -35,5 +35,5 @@
                "document opened:" 
                (.-fileName doc))))))
 
-(when (= (joyride/get-invoked-script) joyride/*file*)
+(when (= (joyride/invoked-script) joyride/*file*)
   (my-main))

--- a/examples/.joyride/scripts/fontsize.cljs
+++ b/examples/.joyride/scripts/fontsize.cljs
@@ -7,7 +7,7 @@
       (.update "editor.fontSize" pts true))
   nil)
 
-(when (= (joyride/get-invoked-script) joyride/*file*)
+(when (= (joyride/invoked-script) joyride/*file*)
   (set-global-fontsize 12))
 
 ;; live demo here: https://twitter.com/borkdude/status/1519709769157775360

--- a/examples/.joyride/scripts/fontsize.cljs
+++ b/examples/.joyride/scripts/fontsize.cljs
@@ -1,13 +1,13 @@
 (ns fontsize
-  (:require ["vscode" :as vscode]))
+  (:require ["vscode" :as vscode]
+            [joyride.core :as joyride]))
 
 (defn set-global-fontsize [pts]
   (-> (vscode/workspace.getConfiguration)
       (.update "editor.fontSize" pts true))
   nil)
 
-(comment
-  (set-global-fontsize 12)
-  )
+(when (= (joyride/get-invoked-script) joyride/*file*)
+  (set-global-fontsize 12))
 
 ;; live demo here: https://twitter.com/borkdude/status/1519709769157775360

--- a/examples/.joyride/scripts/ignore_form.cljs
+++ b/examples/.joyride/scripts/ignore_form.cljs
@@ -17,5 +17,5 @@
       (p/do! (eu/delete-range! editor range-before-insert-position))
       (p/do! (eu/insert-text!+ "#_" editor insert-position)))))
 
-(when (= (joyride/get-invoked-script) joyride/*file*)
+(when (= (joyride/invoked-script) joyride/*file*)
   (main))

--- a/examples/.joyride/scripts/ignore_form.cljs
+++ b/examples/.joyride/scripts/ignore_form.cljs
@@ -1,17 +1,8 @@
 (ns ignore-form
   (:require ["vscode" :as vsode]
+            [joyride.core :as joyride]
             [promesa.core :as p]
             [z-joylib.editor-utils :as eu]))
-
-(def f *file*)
-(defonce run-main? true)
-
-(comment
-  ;; Loading this in the REPL w/o evaluating `main`:
-  (defonce run-main? false)  ; <- First evaluate this
-  (ns-unmap *ns* 'run-main?) ; <- Evaluate this when you are done
-                             ;    or want to test-run the script
-  )
 
 (defn main []
   (p/let [editor ^js vscode/window.activeTextEditor
@@ -26,9 +17,5 @@
       (p/do! (eu/delete-range! editor range-before-insert-position))
       (p/do! (eu/insert-text!+ "#_" editor insert-position)))))
 
-(when run-main?
+(when (= (joyride/get-invoked-script) joyride/*file*)
   (main))
-
-(comment  
-  (main)
-  )

--- a/examples/.joyride/scripts/joyride_api.cljs
+++ b/examples/.joyride/scripts/joyride_api.cljs
@@ -34,30 +34,30 @@
 (comment
   ;; Joyride scripts can also reach the Joyride extension
   ;; through `joyride.core`
-  (-> (joyride/get-extension-context)
+  (-> (joyride/extension-context)
       .-extension
       .-exports)
   (require '[clojure.repl :refer [doc]])
-  (doc joyride/get-extension-context)
+  (doc joyride/extension-context)
   )
 
 ;; in addition to the extension context, joyride.core also has:
 ;; * *file*             - the absolute path of the file where an
 ;;                        evaluation takes place
-;; * get-invoked-script - the absolute path of a script being run
+;; * invoked-script - the absolute path of a script being run
 ;;                        `nil` in other execution contexts
-;; * get-output-channel - Joyride's output channel
+;; * output-channel - Joyride's output channel
 
-(doto (joyride/get-output-channel)
+(doto (joyride/output-channel)
   (.show true)
   (.append "Writing to the ")
   (.appendLine "Joyride output channel.")
   (.appendLine (str "Joyride extension path: "
-                    (-> (joyride/get-extension-context)
+                    (-> (joyride/extension-context)
                         .-extension
                         .-extensionPath)))
   (.appendLine (str "joyride/*file*: " joyride/*file*))
-  (.appendLine (str "Invoked script: " (joyride/get-invoked-script)))
+  (.appendLine (str "Invoked script: " (joyride/invoked-script)))
   (.appendLine "🎉"))
 
 ;; Try both invoking this file as a script, and loading it in the REPL

--- a/examples/.joyride/scripts/joyride_api.cljs
+++ b/examples/.joyride/scripts/joyride_api.cljs
@@ -1,6 +1,7 @@
 (ns joyride-api
   (:require ["vscode" :as vscode]
-            [promesa.core :as p]))
+            [promesa.core :as p]
+            [joyride.core :as joyride]))
 
 (def joyrideExt (vscode/extensions.getExtension "betterthantomorrow.joyride"))
 (def joyApi (.-exports joyrideExt))
@@ -33,10 +34,30 @@
 (comment
   ;; Joyride scripts can also reach the Joyride extension
   ;; through `joyride.core`
-  (require '[joyride.core :as joyride])
-  (require '[clojure.repl :refer [doc]])
   (-> (joyride/get-extension-context)
       .-extension
       .-exports)
+  (require '[clojure.repl :refer [doc]])
   (doc joyride/get-extension-context)
   )
+
+;; in addition to the extension context, joyride.core also has:
+;; * *file*             - the absolute path of the file where an
+;;                        evaluation takes place
+;; * get-invoked-script - the absolute path of a script being run
+;;                        `nil` in other execution contexts
+;; * get-output-channel - Joyride's output channel
+
+(doto (joyride/get-output-channel)
+  (.show true)
+  (.append "Writing to the ")
+  (.appendLine "Joyride output channel.")
+  (.appendLine (str "Joyride extension path: "
+                    (-> (joyride/get-extension-context)
+                        .-extension
+                        .-extensionPath)))
+  (.appendLine (str "joyride/*file*: " joyride/*file*))
+  (.appendLine (str "Invoked script: " (joyride/get-invoked-script)))
+  (.appendLine "🎉"))
+
+;; Try both invoking this file as a script, and loading it in the REPL

--- a/examples/.joyride/scripts/open_document.cljs
+++ b/examples/.joyride/scripts/open_document.cljs
@@ -18,5 +18,5 @@
                     "No" :no
                     :none)))))
 
-(when (= (joyride/get-invoked-script) joyride/*file*)
+(when (= (joyride/invoked-script) joyride/*file*)
   (my-main))

--- a/examples/.joyride/scripts/open_document.cljs
+++ b/examples/.joyride/scripts/open_document.cljs
@@ -1,6 +1,7 @@
 (ns open-document
-  (:require [promesa.core :as p]
-            ["vscode" :as vscode]))
+  (:require ["vscode" :as vscode]
+            [joyride.core :as joyride]
+            [promesa.core :as p]))
 
 (defn show-random-example []
   (p/let [examples (vscode/workspace.findFiles ".joyride/scripts/**/*.cljs")
@@ -9,9 +10,13 @@
           (vscode/window.showTextDocument
            #js {:preview false, :preserveFocus false}))))
 
-(p/-> (vscode/window.showInformationMessage "Welcome to the Joyride examples workspace. Want to look at a random example?" "Yes" "No")
-      (p/then (fn [choice]
-                (case choice
-                  "Yes" (show-random-example)
-                  "No" :no
-                  :none))))
+(defn my-main []
+  (p/-> (vscode/window.showInformationMessage "Welcome to the Joyride examples workspace. Want to look at a random example?" "Yes" "No")
+        (p/then (fn [choice]
+                  (case choice
+                    "Yes" (show-random-example)
+                    "No" :no
+                    :none)))))
+
+(when (= (joyride/get-invoked-script) joyride/*file*)
+  (my-main))

--- a/examples/.joyride/scripts/terminal.cljs
+++ b/examples/.joyride/scripts/terminal.cljs
@@ -1,19 +1,20 @@
 (ns terminal
-  (:require ["os" :as os]
-            ["path" :as path]
-            ["vscode" :as vscode]))
+  (:require ["vscode" :as vscode]
+            [joyride.core :as joyride]))
 
-;; start a terminal called nbb in $HOME/dev/nbb
-(def terminal
-  (vscode/window.createTerminal
-   #js {:name "nbb"
-        :cwd (path/join (os/homedir) "dev" "nbb")}))
+(defn main []
+   ;; start a terminal called nbb in $HOME/dev/nbb
+  (let [terminal (vscode/window.createTerminal
+                  #js {:name "nbb"})]
+    
+    ;; make it visible
+    (.show terminal true)
 
-;; make it visible
-(terminal.show true)
+    ;; send an initial command to it
+    (.sendText terminal "npx nbb")))
 
-;; send an initial command to it
-(terminal.sendText "bb dev")
+(when (= (joyride/get-invoked-script) joyride/*file*)
+  (main))
 
 ;; see live demo here:
 ;; https://twitter.com/borkdude/status/1519304323703971841

--- a/examples/.joyride/scripts/terminal.cljs
+++ b/examples/.joyride/scripts/terminal.cljs
@@ -13,7 +13,7 @@
     ;; send an initial command to it
     (.sendText terminal "npx nbb")))
 
-(when (= (joyride/get-invoked-script) joyride/*file*)
+(when (= (joyride/invoked-script) joyride/*file*)
   (main))
 
 ;; see live demo here:

--- a/examples/.joyride/scripts/webview/example.cljs
+++ b/examples/.joyride/scripts/webview/example.cljs
@@ -16,7 +16,7 @@
           html (.decode (js/TextDecoder. "utf-8") data)]
     (set! (.. panel -webview -html) (str html))))
 
-(when (= (joyride/get-invoked-script) joyride/*file*)
+(when (= (joyride/invoked-script) joyride/*file*)
   (main))
 
 ;; live demo here: https://twitter.com/borkdude/status/1519607386218053632

--- a/examples/.joyride/scripts/webview/example.cljs
+++ b/examples/.joyride/scripts/webview/example.cljs
@@ -1,18 +1,22 @@
 (ns webview.example
-  (:require ["fs" :as fs]
-            ["path" :as path]
-            ["vscode" :as vscode]))
+  (:require ["path" :as path]
+            ["vscode" :as vscode]
+            [joyride.core :as joyride]
+            [promesa.core :as p]))
 
-(def panel
-  (vscode/window.createWebviewPanel
-   "My webview!" "Scittle"
-   vscode/ViewColumn.One
-   #js {:enableScripts true}))
+(defn main []
+  (p/let [panel (vscode/window.createWebviewPanel
+                 "My webview!" "Scittle"
+                 vscode/ViewColumn.One
+                 #js {:enableScripts true})
+          uri (vscode/Uri.file (path/join vscode/workspace.rootPath
+                                          ".joyride" "scripts" "webview"
+                                          "page.html"))
+          data (vscode/workspace.fs.readFile uri)
+          html (.decode (js/TextDecoder. "utf-8") data)]
+    (set! (.. panel -webview -html) (str html))))
 
-(def html (fs/readFileSync (path/join vscode/workspace.rootPath
-                                      ".joyride" "scripts" "webview"
-                                      "page.html")))
-
-(set! (.. panel -webview -html) (str html))
+(when (= (joyride/get-invoked-script) joyride/*file*)
+  (main))
 
 ;; live demo here: https://twitter.com/borkdude/status/1519607386218053632

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ In the `.joyride/scripts` folder you'll find mostly small examples:
 
 A Workspace [activate.cljs] script that registers a `vscode/workspace.onDidOpenTextDocument` event handler. Demonstrates:
 
-* Using the `joyride.core/get-extension-context` to push disposables on its `subscriptions` array. Making VS Code dispose of them when Joyride is deactivated.
+* Using the `joyride.core/extension-context` to push disposables on its `subscriptions` array. Making VS Code dispose of them when Joyride is deactivated.
 * A re-runnable recipe to avoid re-registering the event handler. (By disposing it and then re-register.)
 
 ## Create a Webview

--- a/examples/README.md
+++ b/examples/README.md
@@ -68,9 +68,13 @@ the default Windows comment keyboard shortcut.
 
 ## Joyride API
 
-Yes, you can script Joyride with Joyride. See the [Joyride API docs](../doc/api.md) for more about this.
+Joyride comes with the `joyride.core` namespace, giving you access to things as the extension context, the Joyride output channel, and some info about the evaluation environment.
+
+And, you can also script Joyride with Joyride using its Extension API.
 
 Example script: [`.joyride/scripts/joyride_api.cljs`](.joyride/scripts/joyride_api.cljs)
+
+See also: the [Joyride API docs](../doc/api.md)
 
 ## Opening a file
 

--- a/playground/hello-joyride/.joyride/scripts/hello.cljs
+++ b/playground/hello-joyride/.joyride/scripts/hello.cljs
@@ -11,7 +11,7 @@
 (comment
   j/*file*
 
-  (def ext-ctx (joyride/get-extension-context))
+  (def ext-ctx (joyride/extension-context))
   (.-extensionPath ext-ctx)
   )
 

--- a/src/main/joyride/db.cljs
+++ b/src/main/joyride/db.cljs
@@ -1,3 +1,26 @@
 (ns joyride.db)
 
-(defonce !app-db (atom {}))
+(def init-db {:output-channel nil
+              :extension-context nil
+              :invoked-script nil
+              :disposables []})
+
+(defonce !app-db (atom init-db))
+
+(defn get-extension-context
+  "Returns the Joyride ExtensionContext instance.
+   See: https://code.visualstudio.com/api/references/vscode-api#ExtensionContext"
+  []
+  (:extension-context @!app-db))
+
+(defn get-invoked-script
+  "Returns the absolute path of the invoked script when the evaluation is made
+   through *Run Script*, otherwise returns `nil`."
+  []
+  (:invoked-script @!app-db))
+
+(defn get-output-channel
+  "Returns the Joyride OutputChannel instance.
+   See: https://code.visualstudio.com/api/references/vscode-api#OutputChannel"
+  []
+  (:output-channel @!app-db))

--- a/src/main/joyride/db.cljs
+++ b/src/main/joyride/db.cljs
@@ -7,19 +7,19 @@
 
 (defonce !app-db (atom init-db))
 
-(defn get-extension-context
+(defn extension-context
   "Returns the Joyride ExtensionContext instance.
    See: https://code.visualstudio.com/api/references/vscode-api#ExtensionContext"
   []
   (:extension-context @!app-db))
 
-(defn get-invoked-script
+(defn invoked-script
   "Returns the absolute path of the invoked script when the evaluation is made
    through *Run Script*, otherwise returns `nil`."
   []
   (:invoked-script @!app-db))
 
-(defn get-output-channel
+(defn output-channel
   "Returns the Joyride OutputChannel instance.
    See: https://code.visualstudio.com/api/references/vscode-api#OutputChannel"
   []

--- a/src/main/joyride/extension.cljs
+++ b/src/main/joyride/extension.cljs
@@ -92,11 +92,12 @@
 
 (defn ^:export activate [^js context]
   (when context
-    (reset! db/!app-db {:output-channel (vscode/window.createOutputChannel "Joyride")
-                 :extension-context context
-                 :disposables []})
-    (utils/say "🟢 Joyride VS Code with Clojure. 🚗")
-    (p/-> (life-cycle/maybe-run-init-script+ run-user-script+ 
+    (swap! db/!app-db assoc
+           :output-channel (vscode/window.createOutputChannel "Joyride")
+           :extension-context context)
+    (binding [utils/*show-when-said?* true]
+      (utils/say "🟢 Joyride VS Code with Clojure. 🚗"))
+    (p/-> (life-cycle/maybe-run-init-script+ run-user-script+
                                              (:user life-cycle/init-scripts))
           (p/then
            (fn [_result]

--- a/src/main/joyride/extension.cljs
+++ b/src/main/joyride/extension.cljs
@@ -88,7 +88,7 @@
 
 (def api (jsify {:startNReplServer start-nrepl-server+
                  :getContextValue (fn [k]
-                                    (when-contexts/get-context k))}))
+                                    (when-contexts/context k))}))
 
 (defn ^:export activate [^js context]
   (when context

--- a/src/main/joyride/extension.cljs
+++ b/src/main/joyride/extension.cljs
@@ -51,9 +51,11 @@
    (-> (p/let [abs-path (path/join base-path scripts-path script-path)
                script-uri (vscode/Uri.file abs-path)
                code (vscode-read-uri+ script-uri)]
+         (swap! db/!app-db assoc :invoked-script abs-path)
          (sci/with-bindings {sci/file abs-path}
            (jsci/eval-string code)))
        (p/handle (fn [result error]
+                   (swap! db/!app-db assoc :invoked-script nil)
                    (if error
                      (do
                        (utils/say-error (str title " Failed: " script-path " " (.-message error)))

--- a/src/main/joyride/nrepl.cljs
+++ b/src/main/joyride/nrepl.cljs
@@ -197,7 +197,7 @@
                     (vscode/workspace.fs.delete uri)))))))
 
 (defn server-running? []
-  (when-contexts/get-context ::when-contexts/joyride.isNReplServerRunning))
+  (when-contexts/context ::when-contexts/joyride.isNReplServerRunning))
 
 (defn- start-server'+
   "Start nRepl server. Accepts options either as JS object or Clojure map."

--- a/src/main/joyride/sci.cljs
+++ b/src/main/joyride/sci.cljs
@@ -26,9 +26,9 @@
               :namespaces (assoc
                            (:namespaces pconfig/config)
                            'joyride.core {'*file* sci/file
-                                          'get-extension-context (sci/copy-var db/get-extension-context joyride-ns)
-                                          'get-invoked-script (sci/copy-var db/get-invoked-script joyride-ns)
-                                          'get-output-channel (sci/copy-var db/get-output-channel joyride-ns)})
+                                          'extension-context (sci/copy-var db/extension-context joyride-ns)
+                                          'invoked-script (sci/copy-var db/invoked-script joyride-ns)
+                                          'output-channel (sci/copy-var db/output-channel joyride-ns)})
               :load-fn (fn [{:keys [namespace opts]}]
                          (cond
                            (symbol? namespace)

--- a/src/main/joyride/sci.cljs
+++ b/src/main/joyride/sci.cljs
@@ -13,54 +13,45 @@
 
 (def joyride-ns (sci/create-ns 'joyride.core nil))
 
-(defn get-extension-context
-  "Returns the Joyride extension context object.
-   See: https://code.visualstudio.com/api/references/vscode-api#ExtensionContext"
-  []
-  (:extension-context @db/!app-db))
-
-(defn get-invoked-script
-  "Returns the absolute path of theinvoked script when the evaluation is made
-   through *Run Script*, otherwise returns `nil`."
-  []
-  (:invoked-script @db/!app-db))
-
 (defn ns->path [namespace]
   (-> (str namespace)
       (munge)
       (str/replace  "." "/")
       (str ".cljs")))
 
-(def !ctx (volatile!
-           (sci/init {:classes {'js goog/global
-                                :allow :all}
-                      :namespaces (assoc (:namespaces pconfig/config)
-                                         'joyride.core {'*file* sci/file
-                                                        'get-extension-context (sci/copy-var get-extension-context joyride-ns)
-                                                        'get-invoked-script (sci/copy-var get-invoked-script joyride-ns)})
-                      :load-fn (fn [{:keys [namespace opts]}]
-                                 (cond
-                                   (symbol? namespace)
-                                   {:source
-                                    (let [path (ns->path namespace)]
-                                      (str
-                                       (fs/readFileSync
-                                        (path/join
-                                         (utils/workspace-root)
-                                         workspace-scripts-path
-                                         path))))}
-                                   (string? namespace) ;; node built-in or npm library
-                                   (if (= "vscode" namespace)
-                                     (do (sci/add-class! @!ctx 'vscode vscode)
-                                         (sci/add-import! @!ctx (symbol (str @sci/ns)) 'vscode (:as opts))
-                                         {:handled true})
-                                     (let [mod (js/require namespace)
-                                           ns-sym (symbol namespace)]
-                                       (sci/add-class! @!ctx ns-sym mod)
-                                       (sci/add-import! @!ctx (symbol (str @sci/ns)) ns-sym
-                                                        (or (:as opts)
-                                                            ns-sym))
-                                       {:handled true}))))})))
+(def !ctx
+  (volatile!
+   (sci/init {:classes {'js goog/global
+                        :allow :all}
+              :namespaces (assoc
+                           (:namespaces pconfig/config)
+                           'joyride.core {'*file* sci/file
+                                          'get-extension-context (sci/copy-var db/get-extension-context joyride-ns)
+                                          'get-invoked-script (sci/copy-var db/get-invoked-script joyride-ns)
+                                          'get-output-channel (sci/copy-var db/get-output-channel joyride-ns)})
+              :load-fn (fn [{:keys [namespace opts]}]
+                         (cond
+                           (symbol? namespace)
+                           {:source
+                            (let [path (ns->path namespace)]
+                              (str
+                               (fs/readFileSync
+                                (path/join
+                                 (utils/workspace-root)
+                                 workspace-scripts-path
+                                 path))))}
+                           (string? namespace) ;; node built-in or npm library
+                           (if (= "vscode" namespace)
+                             (do (sci/add-class! @!ctx 'vscode vscode)
+                                 (sci/add-import! @!ctx (symbol (str @sci/ns)) 'vscode (:as opts))
+                                 {:handled true})
+                             (let [mod (js/require namespace)
+                                   ns-sym (symbol namespace)]
+                               (sci/add-class! @!ctx ns-sym mod)
+                               (sci/add-import! @!ctx (symbol (str @sci/ns)) ns-sym
+                                                (or (:as opts)
+                                                    ns-sym))
+                               {:handled true}))))})))
 
 (def !last-ns (volatile! @sci/ns))
 

--- a/src/main/joyride/sci.cljs
+++ b/src/main/joyride/sci.cljs
@@ -11,13 +11,19 @@
 
 (sci/alter-var-root sci/print-fn (constantly *print-fn*))
 
+(def joyride-ns (sci/create-ns 'joyride.core nil))
+
 (defn get-extension-context
   "Returns the Joyride extension context object.
    See: https://code.visualstudio.com/api/references/vscode-api#ExtensionContext"
   []
   (:extension-context @db/!app-db))
 
-(def joyride-ns (sci/create-ns 'joyride.core nil))
+(defn get-invoked-script
+  "Returns the absolute path of theinvoked script when the evaluation is made
+   through *Run Script*, otherwise returns `nil`."
+  []
+  (:invoked-script @db/!app-db))
 
 (defn ns->path [namespace]
   (-> (str namespace)
@@ -30,7 +36,8 @@
                                 :allow :all}
                       :namespaces (assoc (:namespaces pconfig/config)
                                          'joyride.core {'*file* sci/file
-                                                        'get-extension-context (sci/copy-var get-extension-context joyride-ns)})
+                                                        'get-extension-context (sci/copy-var get-extension-context joyride-ns)
+                                                        'get-invoked-script (sci/copy-var get-invoked-script joyride-ns)})
                       :load-fn (fn [{:keys [namespace opts]}]
                                  (cond
                                    (symbol? namespace)

--- a/src/main/joyride/utils.cljs
+++ b/src/main/joyride/utils.cljs
@@ -47,7 +47,7 @@
 (def ^{:dynamic true
        :doc "Should the Joyride output channel be revealed after `say`?
              Default: `true`"}
-  *show-when-said?* true)
+  *show-when-said?* false)
 
 (defn say [message]
   (let [channel ^js (:output-channel @db/!app-db)]

--- a/src/main/joyride/when_contexts.cljs
+++ b/src/main/joyride/when_contexts.cljs
@@ -8,10 +8,10 @@
   (swap! !db assoc-in [:contexts k] v)
   (vscode/commands.executeCommand "setContext" (name k) v))
 
-(defn get-context [k]
+(defn context [k]
   (get-in @!db [:contexts (if (string? k)
                             (keyword (str "joyride.when-contexts/" k))
                             k)]))
 
 (comment
-  (get-context "joyride.isActive"))
+  (context "joyride.isActive"))


### PR DESCRIPTION
* Stops always showing the Joyride output channel on script runs
* Adds `joyride.core/get-output-channel` function
* Update to Joyride API example

Fixes #36

NB: This PR builds on to of #39, so please review that one first.