### PR TITLE
Don't catch error when reading script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Joyride
 ## [Unreleased]
 
 - [Error when dismissing the scripts menu without selecting anything](https://github.com/BetterThanTomorrow/joyride/issues/24)
+- Fix: [Better error report when a script isn't found](https://github.com/BetterThanTomorrow/joyride/issues/40)
 
 ## [0.0.8] - 2022-05-09
 

--- a/src/main/joyride/extension.cljs
+++ b/src/main/joyride/extension.cljs
@@ -55,7 +55,8 @@
        (p/handle (fn [result error]
                    (swap! db/!app-db assoc :invoked-script nil)
                    (if error
-                     (utils/say-error (str title " Failed: " script-path " " (.-message error)))
+                     (binding [utils/*show-when-said?* true]
+                       (utils/say-error (str title " Failed: " script-path " " (.-message error))))
                      (do (utils/say-result (str script-path " evaluated.") result)
                          result)))))))
 

--- a/src/main/joyride/extension.cljs
+++ b/src/main/joyride/extension.cljs
@@ -55,9 +55,7 @@
        (p/handle (fn [result error]
                    (swap! db/!app-db assoc :invoked-script nil)
                    (if error
-                     (do
-                       (utils/say-error (str title " Failed: " script-path " " (.-message error)))
-                       (js/console.error title "Failed: " script-path (.-message error) error))
+                     (utils/say-error (str title " Failed: " script-path " " (.-message error)))
                      (do (utils/say-result (str script-path " evaluated.") result)
                          result)))))))
 

--- a/src/main/joyride/utils.cljs
+++ b/src/main/joyride/utils.cljs
@@ -27,10 +27,7 @@
                 data (vscode/workspace.fs.readFile uri)
                 decoder (js/TextDecoder. "utf-8")
                 code (.decode decoder data)]
-          code)
-        (p/catch
-            (fn [e]
-              (js/console.error "Reading file failed: " (.-message e)))))))
+          code))))
 
 (defn workspace-root []
   vscode/workspace.rootPath)


### PR DESCRIPTION
We were catching the file not found error when reading the script and logging the error to the JS console. Now we catch the error ”at the edge” and print it to the Joyride output channel, and show it.

Fixes #40