### PR TITLE
add user script directory to search paths of 'require'

### DIFF
--- a/src/main/joyride/sci.cljs
+++ b/src/main/joyride/sci.cljs
@@ -4,8 +4,7 @@
             ["vscode" :as vscode]
             [clojure.string :as str]
             [joyride.db :as db]
-            [joyride.config :refer [workspace-abs-scripts-path user-abs-scripts-path]]
-            [joyride.utils :as utils]
+            [joyride.config :as conf]
             [sci-configs.funcool.promesa :as pconfig]
             [sci.core :as sci]))
 
@@ -27,7 +26,7 @@
                              file-path)))
         ;; workspace first, then user - the and is a nil check for no workspace
         path-to-load (first (keep #(and % (path-if-exists %))
-                                  [(workspace-abs-scripts-path) (user-abs-scripts-path)]))]
+                                  [(conf/workspace-abs-scripts-path) (conf/user-abs-scripts-path)]))]
     (when path-to-load
       {:file ns-path
        :source (str (fs/readFileSync path-to-load))})))


### PR DESCRIPTION
fixes #38 

With this change, `(require)` checks the workspace scripts directory first, then the user script directory, then fails. It incidentally also adds a nil check on the workspace root before trying to load it, so in cases where Joyride currently complains about a null when requiring a script with no workspace loaded, this prevents the call to `path/join` if there's no workspace root. Finally, if there's no matching file in the workspace or user scripts directory, Joyride currently presents a JS-ish error message (`ENOENT`). This change returns nil from sci's `:load-fn` if no matching files are found, resulting in the message `Could not find namespace: missing-ns`.

It does still use the synchronous fs stuff for now.