### PR TITLE
WIP: Use latest sci.configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Joyride
 
 ## [Unreleased]
 
+- [Enable access to more `promesa.core` vars](https://github.com/BetterThanTomorrow/joyride/issues/68)
+
 ## [0.0.11] - 2022-05-15
 
 - Fix: [`(require)` does not load ns from user script dir](https://github.com/BetterThanTomorrow/joyride/issues/38)

--- a/deps.edn
+++ b/deps.edn
@@ -6,5 +6,7 @@
         {:git/url "https://github.com/babashka/sci"
          :git/sha "07e21bdab3c1365f7b2a06377e1c56fa09e95a15"}
         org.babashka/sci-configs
+        #_{:local/root "../sci.configs"}
         {:git/url "https://github.com/babashka/sci-configs"
-         :git/sha "d197da2413bd8e4e5c43159620ddfe4286c731ba"}}}
+         :git/sha "fcd367c6a6115c5c4e41f3a08ee5a8d5b3387a18"}}
+ :aliases {:dev {}}}

--- a/doc/api.md
+++ b/doc/api.md
@@ -28,6 +28,8 @@ In addition to `clojure.core`, `clojure.set`, `clojure.edn`, `clojure.string`,
 `clojure.walk`, `clojure.data`, Joyride exposes
 the following namespaces:
 
+Lacking some particular library? Please consider contributing to [babashka/sci.configs](https://github.com/babashka/sci.configs)!
+
 #### `joyride.core`
 
 - `*file*`: dynamic var holding the absolute path of file where the current evaluation is taking place
@@ -65,7 +67,56 @@ Here's a snippet from the [joyride_api.cljs](../examples/.joyride/scripts/joyrid
 
 See [promesa docs](https://cljdoc.org/d/funcool/promesa/6.0.2/doc/user-guide).
 
-**``**: `p/->>`, `p/->`, `p/all`, `p/any`, `p/catch`, `p/chain`, `p/create`, `p/deferred`, `p/delay`, `p/do`, `p/do!`, `p/done?`, `p/finally`, `p/let`, `p/map`, `p/mapcat`, `p/pending`, `p/promise`, `p/promise?`, `p/race`, `p/rejected`, `p/rejected?`, `p/resolved`, `p/resolved?`, `p/run!`, `p/then`, `p/thenable?`, `p/with`, and `p/wrap`
+- `p/*loop-run-fn*`
+- `p/->`
+- `p/->>`
+- `p/TimeoutException`
+- `p/all`
+- `p/any`
+- `p/as->`
+- `p/bind`
+- `p/cancel!`
+- `p/cancelled?`
+- `p/catch`
+- `p/catch'`
+- `p/chain`
+- `p/chain'`
+- `p/create`
+- `p/deferred`
+- `p/deferred?`
+- `p/delay`
+- `p/do`
+- `p/do!`
+- `p/done?`
+- `p/err`
+- `p/error`
+- `p/finally`
+- `p/future`
+- `p/handle`
+- `p/let`
+- `p/loop`
+- `p/map`
+- `p/mapcat`
+- `p/pending?`
+- `p/plet`
+- `p/promise`
+- `p/promise?`
+- `p/promisify`
+- `p/race`
+- `p/recur`
+- `p/reject!`
+- `p/rejected`
+- `p/rejected?`
+- `p/resolve!`
+- `p/resolved`
+- `p/resolved?`
+- `p/run!`
+- `p/then`
+- `p/then'`
+- `p/thenable?`
+- `p/timeout`
+- `p/with-redefs`
+- `p/wrap`
 
 ### Possibly coming additions
 

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     ]
   },
   "scripts": {
-    "clean": "rimraf .shadow-cljs/ out/",
+    "clean": "rimraf .cpcache .shadow-cljs/ out/",
     "watch": "npx shadow-cljs -d cider/cider-nrepl:0.27.4 watch :extension",
     "prewatch": "npm run clean",
     "compile": "npx shadow-cljs compile :extension",

--- a/src/joyride/sci.cljs
+++ b/src/joyride/sci.cljs
@@ -5,7 +5,7 @@
             [clojure.string :as str]
             [joyride.db :as db]
             [joyride.config :as conf]
-            [sci-configs.funcool.promesa :as pconfig]
+            [sci.configs.funcool.promesa :as pconfig]
             [sci.core :as sci]))
 
 (sci/alter-var-root sci/print-fn (constantly *print-fn*))


### PR DESCRIPTION
Trying to get at `p/handle` et al, which were added in a more recent sci.configs.

However, right now not getting it to work, even though it works if I use `:local/deps`

Seeing the same in `nbb`, I think:

```
% npx nbb -e "(require 'promesa.core) promesa.core/handle"
Need to install the following packages:
  nbb
Ok to proceed? (y) 
----- Error --------------------------------------
Message:  Could not resolve symbol: promesa.core/handle
Location: 1:25
Phase:    analysis
Could not resolve symbol: promesa.core/handle
```

UPDATE: That was not so, `npx` seems to give me some old version:

```
npx nbb --version                                       
Need to install the following packages:
  nbb
Ok to proceed? (y) 
----- Error --------------------------------------
Message:  ENOENT: no such file or directory, open '/Users/pez/Projects/joyride/--version'
ENOENT: no such file or directory, open '/Users/pez/Projects/joyride/--version'
~/Projects/joyride(pez/bump-sci-configs-dep|✔) % nbb --version
zsh: command not found: nbb
~/Projects/joyride(pez/bump-sci-configs-dep|✔) % npm install -g nbb

added 6 packages, and audited 7 packages in 3s

1 package is looking for funding
  run `npm fund` for details

found 0 vulnerabilities
~/Projects/joyride(pez/bump-sci-configs-dep|✔) % nbb --version     
nbb v0.5.103
~/Projects/joyride(pez/bump-sci-configs-dep|✔) % nbb -e "(require 'promesa.core) promesa.core/handle" 
#object[n$]
```

So it totally works with latest nbb.