### PR TITLE
Enable requiring extension exports as JS lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Joyride
 
 ## [Unreleased]
 
+- [Less boilerplate-y require of APIs from VS Code extensions](https://github.com/BetterThanTomorrow/joyride/issues/71)
+
 ## [0.0.12] - 2022-05-18
 
 - [Enable access to more `promesa.core` vars](https://github.com/BetterThanTomorrow/joyride/issues/68)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ https://user-images.githubusercontent.com/30010/165934412-ffeb5729-07be-4aa5-b29
 
 Joyride is Powered by [SCI](https://github.com/babashka/sci) (Small Clojure Interpreter).
 
+See [doc/api.md](https://github.com/BetterThanTomorrow/joyride/blob/master/doc/api.md) for documentation about the Joyride API.
+
 ## WIP
 
 You are entering a construction yard. Things are going to change and break your configs while we are searching for good APIs and UI/Ux.

--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,7 @@
         org.babashka/sci
         #_{:local/root "../babashka/sci"}
         {:git/url "https://github.com/babashka/sci"
-         :git/sha "07e21bdab3c1365f7b2a06377e1c56fa09e95a15"}
+         :git/sha "37722fb5e49970fe428781b287f478d8310fd3df"}
         org.babashka/sci-configs
         #_{:local/root "../sci.configs"}
         {:git/url "https://github.com/babashka/sci-configs"

--- a/doc/api.md
+++ b/doc/api.md
@@ -22,7 +22,33 @@ You can make some code run when Joyride activates, by naming the scripts `activa
 
 Look at the [Activation example](../examples/.joyride/scripts/activate.cljs) script for a way to use this, and for a way to make the script re-runnable.
 
-### Namespaces
+### NPM modules
+
+TBD.
+
+### VS Code, and Extension ”namespaces”
+
+Joyride exposes its `vscode` module for scripts to consume. You require it like so:
+
+```clojure
+(ns joyride-api
+  (:require ...
+            ["vscode" :as vscode]
+            ...))
+```
+
+VS Code Extensions that export an API can be required using the `ext://` prefix followed by the extension identifier. For instance, to require [Calva's Extension API](https://calva.io/api/) use `"ext://betterthantomorrow.calva"`. Optionally you can specify any submodules in the exported API by suffixing the namespace with a `$` followed by the dotted path of the submodule. You can also `refer` objects in the API and submodules. Like so:
+
+```clojure
+(ns z-joylib.calva-api
+  (:require ...
+            ["ext://betterthantomorrow.calva$v0" :as calva :refer [repl ranges]])
+            ...)
+
+(def current-form-text (second (ranges.currentForm)))
+```
+
+### ClojureScript Namespaces
 
 In addition to `clojure.core`, `clojure.set`, `clojure.edn`, `clojure.string`,
 `clojure.walk`, `clojure.data`, Joyride exposes

--- a/examples/.joyride/scripts/joyride_api.cljs
+++ b/examples/.joyride/scripts/joyride_api.cljs
@@ -1,14 +1,14 @@
 (ns joyride-api
   (:require ["vscode" :as vscode]
+            ["ext://betterthantomorrow.joyride" :as joy-api]
             [promesa.core :as p]
             [joyride.core :as joyride]))
 
 (def joyrideExt (vscode/extensions.getExtension "betterthantomorrow.joyride"))
-(def joyApi (.-exports joyrideExt))
 
 (comment
   ;; Starting the nREPL server
-  (-> (.startNReplServer joyApi)
+  (-> (joy-api/startNReplServer)
       (p/catch (fn [e] (println (.-message e) e))))
   ;; (Oh, yes, it's already started, of course.)
   ;; Try first stopping the server? That will not help,
@@ -18,13 +18,13 @@
 
 (comment
   ;; Getting contexts
-  (.getContextValue joyApi "joyride.isNReplServerRunning")
-  
+  (joy-api/getContextValue "joyride.isNReplServerRunning")
+
   ;; Non-Joyride context keys returns `nil`
-  (.getContextValue joyApi "foo.bar")
+  (joy-api/getContextValue "foo.bar")
 
   ;; NB: Use the extension instance for this!
-  (.getContextValue joyApi "joyride.isActive")
+  (joy-api/getContextValue "joyride.isActive")
   ;; Like so:
   (.-isActive joyrideExt)
   ;; (Not that it matters, you can't deactivate Joyride,
@@ -38,8 +38,7 @@
       .-extension
       .-exports)
   (require '[clojure.repl :refer [doc]])
-  (doc joyride/extension-context)
-  )
+  (doc joyride/extension-context))
 
 ;; in addition to the extension context, joyride.core also has:
 ;; * *file*             - the absolute path of the file where an

--- a/src/joyride/sci.cljs
+++ b/src/joyride/sci.cljs
@@ -32,15 +32,15 @@
       {:file ns-path
        :source (str (fs/readFileSync path-to-load))})))
 
-
 (defn- active-extension? [namespace]
-  (let [[extension-name _module-name] (str/split namespace #"\$")
-        extension (vscode/extensions.getExtension extension-name)]
-    (and extension
-         (.-isActive extension))))
+  (when (.startsWith namespace ".")
+    (let [[extension-name _module-name] (str/split (subs namespace 1) #"\$")
+          extension (vscode/extensions.getExtension extension-name)]
+      (and extension
+           (.-isActive extension)))))
 
 (defn- extension-module [namespace]
-  (let [[extension-name module-name] (str/split namespace #"\$")
+  (let [[extension-name module-name] (str/split (subs namespace 1) #"\$")
         extension (vscode/extensions.getExtension extension-name)]
     (when extension
       (when-let [exports (.-exports extension)]

--- a/src/joyride/sci.cljs
+++ b/src/joyride/sci.cljs
@@ -39,13 +39,13 @@
 
 (defn- active-extension? [namespace]
   (when (.startsWith namespace extension-namespace-prefix)
-    (let [[extension-name _module-name] (str/split (extract-extension-name namespace) #"\$")
+    (let [[extension-name _module-name] (.split (extract-extension-name namespace) "$")
           extension (vscode/extensions.getExtension extension-name)]
       (and extension
            (.-isActive extension)))))
 
 (defn- extension-module [namespace]
-  (let [[extension-name module-name] (str/split (extract-extension-name namespace) #"\$")
+  (let [[extension-name module-name] (.split (extract-extension-name namespace) "$")
         extension (vscode/extensions.getExtension extension-name)]
     (when extension
       (when-let [exports (.-exports extension)]

--- a/src/joyride/sci.cljs
+++ b/src/joyride/sci.cljs
@@ -51,8 +51,7 @@
       (when-let [exports (.-exports extension)]
         [module-name
          (if module-name
-           (let [path (.split module-name ".")]
-             (gobject/getValueByKeys exports path))
+           (gobject/getValueByKeys exports (.split module-name "."))
            exports)]))))
 
 (def !ctx

--- a/src/joyride/sci.cljs
+++ b/src/joyride/sci.cljs
@@ -44,10 +44,11 @@
         extension (vscode/extensions.getExtension extension-name)]
     (when extension
       (when-let [exports (.-exports extension)]
-        (if module-name
-          (let [path (str/split module-name #"\.")]
-            (apply gobject/getValueByKeys exports path))
-          exports)))))
+        [module-name
+         (if module-name
+           (let [path (str/split module-name #"\.")]
+             (apply gobject/getValueByKeys exports path))
+           exports)]))))
 
 (def !ctx
   (volatile!
@@ -71,7 +72,7 @@
                                  {:handled true})
 
                              (active-extension? namespace)
-                             (let [module (extension-module namespace)
+                             (let [[module-name module] (extension-module namespace)
                                    ns-sym (symbol (str @sci/ns))
                                    refer (:refer opts)]
                                (sci/add-class! @!ctx (symbol namespace) module)
@@ -79,7 +80,7 @@
                                (when refer
                                  (doseq [sym refer]
                                    (let [prop (gobject/get module sym)
-                                         sub-sym (symbol (str ns-sym "$" sym))]
+                                         sub-sym (symbol (str ns-sym "$" module-name "$" sym))]
                                      (sci/add-class! @!ctx sub-sym prop)
                                      (sci/add-import! @!ctx ns-sym sub-sym sym))))
                                {:handled true})

--- a/src/joyride/sci.cljs
+++ b/src/joyride/sci.cljs
@@ -32,15 +32,20 @@
       {:file ns-path
        :source (str (fs/readFileSync path-to-load))})))
 
+(def ^:private extension-namespace-prefix "ext://")
+
+(defn- extract-extension-name [namespace]
+  (subs namespace (count extension-namespace-prefix)))
+
 (defn- active-extension? [namespace]
-  (when (.startsWith namespace ".")
-    (let [[extension-name _module-name] (str/split (subs namespace 1) #"\$")
+  (when (.startsWith namespace extension-namespace-prefix)
+    (let [[extension-name _module-name] (str/split (extract-extension-name namespace) #"\$")
           extension (vscode/extensions.getExtension extension-name)]
       (and extension
            (.-isActive extension)))))
 
 (defn- extension-module [namespace]
-  (let [[extension-name module-name] (str/split (subs namespace 1) #"\$")
+  (let [[extension-name module-name] (str/split (extract-extension-name namespace) #"\$")
         extension (vscode/extensions.getExtension extension-name)]
     (when extension
       (when-let [exports (.-exports extension)]

--- a/src/joyride/sci.cljs
+++ b/src/joyride/sci.cljs
@@ -46,8 +46,8 @@
       (when-let [exports (.-exports extension)]
         [module-name
          (if module-name
-           (let [path (str/split module-name #"\.")]
-             (apply gobject/getValueByKeys exports path))
+           (let [path (.split module-name ".")]
+             (gobject/getValueByKeys exports path))
            exports)]))))
 
 (def !ctx


### PR DESCRIPTION
I don't really know what I am doing...

![](https://i.imgflip.com/6hvry2.jpg)


I think I am close because:

```clojure
(ns my-lib
  (:require ["vscode" :as vscode]
            ["betterthantomorrow.calva$v0" :as calva-js]
            [joyride.core :as joyride]
            [promesa.core :as p]))

calva-js/repl ; => #js {:evaluateCode #object[Function], :currentSessionKey #object[Function]}

calva-js/repl.evaluateCode ; => #object[Function]
```

But:

```clojure
  (-> (calva-js/repl.evaluateCode "42")
      (p/then (fn [v]
                (js/console.log v)))
      (p/catch (fn [e]
                 (println "Error:" e)))) ; => Error: Error: No protocol method ICounted.-count defined for type number: 0
```

Fixes #71