### PR TITLE
Prefix activation script names with ”classpath”

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Joyride
 
 ## [Unreleased]
 
+- [Use separate namespaces for user and workspace activation scripts](https://github.com/BetterThanTomorrow/joyride/issues/73)
+
 ## [0.0.14] - 2022-05-31
 
 - Add some logging when Joyride starts and finishes activating

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ You can run or open the scripts using commands provided (search the command pale
 * **Joyride Run Workspace Script...**, default keybinding `ctrl+shift+.`
 * **Joyride Open Workspace Script...**
 
+**Note, about namespaces**: Joyride effectively has a classpat that is `user:workspace`. A file `<User scripts dir>/foo_bar.cljs`, will establish/use a namespace `foo-bar`. As will a file `<Workspace scripts dir>/foo_bar.cljs`. Any symbols in these files will be shared/overwritten, as the files are loaded and reloaded. There are probably ways to use this as a power. Please treat it as a super power, because you might also hurt yourself with it.
+
 ## Quickest Start 1 - Run a User Script
 
 Install Joyride. It will run a sample `activate.cljs` User script. You can use this script as a base for init/activation stuff of your VS Code environment.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can run or open the scripts using commands provided (search the command pale
 * **Joyride Run Workspace Script...**, default keybinding `ctrl+shift+.`
 * **Joyride Open Workspace Script...**
 
-**Note, about namespaces**: Joyride effectively has a classpat that is `user:workspace`. A file `<User scripts dir>/foo_bar.cljs`, will establish/use a namespace `foo-bar`. As will a file `<Workspace scripts dir>/foo_bar.cljs`. Any symbols in these files will be shared/overwritten, as the files are loaded and reloaded. There are probably ways to use this as a power. Please treat it as a super power, because you might also hurt yourself with it.
+**Note, about namespaces**: Joyride effectively has a classpath that is `user:workspace`. A file `<User scripts dir>/foo_bar.cljs`, will establish/use a namespace `foo-bar`. As will a file `<Workspace scripts dir>/foo_bar.cljs`. Any symbols in these files will be shared/overwritten, as the files are loaded and reloaded. There are probably ways to use this as a power. Please treat it as a super power, because you might also hurt yourself with it.
 
 ## Quickest Start 1 - Run a User Script
 

--- a/assets/getting-started-content/user/user_activate.cljs
+++ b/assets/getting-started-content/user/user_activate.cljs
@@ -1,4 +1,4 @@
-(ns activate
+(ns user-activate
   (:require ["vscode" :as vscode]
             [promesa.core :as p]
             [joyride.core :as joyride]))
@@ -48,29 +48,29 @@
 ;;; MARK activate.cljs skeleton
 
 ;; Keep tally on VS Code disposables we register
-(defonce !user_db (atom {:disposables []}))
+(defonce !db (atom {:disposables []}))
 
 ;; To make the activation script re-runnable we dispose of
 ;; event handlers and such that we might have registered
 ;; in previous runs.
-(defn- user-clear-disposables! []
+(defn- clear-disposables! []
   (run! (fn [disposable]
           (.dispose disposable))
-        (:disposables @!user_db))
-  (swap! !user_db assoc :disposables []))
+        (:disposables @!db))
+  (swap! !db assoc :disposables []))
 
 ;; Pushing the disposables on the extension context's
 ;; subscriptions will make VS Code dispose of them when the
 ;; Joyride extension is deactivated.
-(defn- user-push-disposable! [disposable]
-  (swap! !user_db update :disposables conj disposable)
+(defn- push-disposable! [disposable]
+  (swap! !db update :disposables conj disposable)
   (-> (joyride/extension-context)
       .-subscriptions
       (.push disposable)))
 
-(defn- user-main []
-  (println "Hello World, from my-main in user activate.cljs script")
-  (user-clear-disposables!) ;; Any disposables add with `push-disposable!`
+(defn- my-main []
+  (println "Hello World, from my-main in user_activate.cljs script")
+  (clear-disposables!) ;; Any disposables add with `push-disposable!`
                        ;; will be cleared now. You can push them anew.
 
   ;;; MARK require VS Code extensions
@@ -98,12 +98,12 @@
                 ;; Registering a symbols provider
                 #_(require '[z-joylib.clojure-symbols :as clojure-symbols])
                 ;; Entering the Gilardi scenario. https://technomancy.us/143
-                #_(user-push-disposable! ((resolve 'clojure-symbols/register-provider!)))))
+                #_(push-disposable! ((resolve 'clojure-symbols/register-provider!)))))
       (p/catch (fn [error]
                  (vscode/window.showErrorMessage (str "Requiring Calva failed: " error))))))
 
 (when (= (joyride/invoked-script) joyride/*file*)
-  (user-main))
+  (my-main))
 
 "🎉"
 

--- a/assets/getting-started-content/workspace/workspace_activate.cljs
+++ b/assets/getting-started-content/workspace/workspace_activate.cljs
@@ -1,39 +1,39 @@
-(ns activate
+(ns workspace-activate
   (:require [joyride.core :as joyride]
             ["vscode" :as vscode]))
 
-(defonce !ws-db (atom {:disposables []}))
+(defonce !db (atom {:disposables []}))
 
 ;; To make the activation script re-runnable we dispose of
 ;; event handlers and such that we might have registered
 ;; in previous runs.
-(defn- ws-clear-disposables! []
+(defn- clear-disposables! []
   (run! (fn [disposable]
           (.dispose disposable))
-        (:disposables @!ws-db))
-  (swap! !ws-db assoc :disposables []))
+        (:disposables @!db))
+  (swap! !db assoc :disposables []))
 
 ;; Pushing the disposables on the extension context's
 ;; subscriptions will make VS Code dispose of them when the
 ;; Joyride extension is deactivated.
-(defn- ws-push-disposable [disposable]
-  (swap! !ws-db update :disposables conj disposable)
+(defn- push-disposable [disposable]
+  (swap! !db update :disposables conj disposable)
   (-> (joyride/extension-context)
       .-subscriptions
       (.push disposable)))
 
-(defn- ws-main []
-  (println "Hello World, from Workspace activate.cljs script")
-  (ws-clear-disposables!)
-  (ws-push-disposable
+(defn- my-main []
+  (println "Hello World, from my-main workspace_activate.cljs script")
+  (clear-disposables!)
+  (push-disposable
    ;; It might surprise you to see how often and when this happens,
    ;; and when it doesn't happen.
    (vscode/workspace.onDidOpenTextDocument
     (fn [doc]
-      (println "[Joyride example]" 
-               (.-languageId doc) 
-               "document opened:" 
+      (println "[Joyride example]"
+               (.-languageId doc)
+               "document opened:"
                (.-fileName doc))))))
 
 (when (= (joyride/invoked-script) joyride/*file*)
-  (ws-main))
+  (my-main))

--- a/examples/.joyride/scripts/workspace_activate.cljs
+++ b/examples/.joyride/scripts/workspace_activate.cljs
@@ -1,4 +1,4 @@
-(ns activate
+(ns workspace-activate
   (:require [joyride.core :as joyride]
             ["vscode" :as vscode]))
 
@@ -23,16 +23,16 @@
       (.push disposable)))
 
 (defn- my-main []
-  (println "Hello World, from Workspace activate.cljs script")
+  (println "Hello World, from my-main workspace_activate.cljs script")
   (clear-disposables!)
   (push-disposable
    ;; It might surprise you to see how often and when this happens,
    ;; and when it doesn't happen.
    (vscode/workspace.onDidOpenTextDocument
     (fn [doc]
-      (println "[Joyride example]" 
-               (.-languageId doc) 
-               "document opened:" 
+      (println "[Joyride example]"
+               (.-languageId doc)
+               "document opened:"
                (.-fileName doc))))))
 
 (when (= (joyride/invoked-script) joyride/*file*)

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ In the `.joyride/scripts` folder you'll find mostly small examples:
 
 One for the Workspace and one on he User level:
 
-### User `activate.cljs`
+### `user_activate.cljs`
 
 A User [activate.cljs](/assets/getting-started-content/user/activate.cljs) script that shows:
 
@@ -20,7 +20,7 @@ A User [activate.cljs](/assets/getting-started-content/user/activate.cljs) scrip
 
 **NB**: This script will be automatically insstalled for you if you do not have a User `activate.cljs` script already.
 
-### Workspace `activate.cljs`
+### `workspace_activate.cljs`
 
 A Workspace [activate.cljs](/examples/.joyride/scripts/activate.cljs) script that registers a `vscode/workspace.onDidOpenTextDocument` event handler. Demonstrates:
 

--- a/src/joyride/getting_started.cljs
+++ b/src/joyride/getting_started.cljs
@@ -27,7 +27,7 @@
 (defn user-activate-uri-section-and-subpath []
   [(conf/user-abs-scripts-path)
    "user"
-   "activate.cljs"])
+   "user_activate.cljs"])
 
 (defn user-hello-uri-section-and-subpath []
   [(conf/user-abs-scripts-path)
@@ -42,7 +42,7 @@
 (defn workspace-activate-uri-section-and-subpath []
   [(conf/workspace-abs-scripts-path)
    "workspace"
-   "activate.cljs"])
+   "workspace_activate.cljs"])
 
 (defn workspace-hello-uri-section-and-subpath []
   [(conf/workspace-abs-scripts-path)

--- a/src/joyride/life_cycle.cljs
+++ b/src/joyride/life_cycle.cljs
@@ -4,12 +4,12 @@
             [joyride.utils :as utils]
             [promesa.core :as p]))
 
-(def user-init-script "activate.cljs")
+(def user-init-script "user_activate.cljs")
 (def user-init-script-path (path/join conf/user-config-path
                                       conf/user-scripts-path
                                       user-init-script))
 
-(def workspace-init-script "activate.cljs")
+(def workspace-init-script "workspace_activate.cljs")
 (def workspace-init-script-path (path/join conf/workspace-scripts-path
                                            workspace-init-script))
 (defn workspace-init-script-abs-path []
@@ -23,7 +23,7 @@
           :script-path user-init-script-path
           :script-abs-path user-init-script-path}
    :workspace {:label "Workspace activate"
-               :script user-init-script
+               :script workspace-init-script
                :script-path workspace-init-script-path
                :script-abs-path (workspace-init-script-abs-path)}})
 

--- a/src/joyride/scripts_handler.cljs
+++ b/src/joyride/scripts_handler.cljs
@@ -174,7 +174,7 @@
     {:title title
      :more-menu-items (cond-> []
                         create-activate-fn (conj {:label (menu-label-with-icon
-                                                          "Create Workspace activate.cljs"
+                                                          "Create Workspace workspace_activate.cljs"
                                                           "plus")
                                                   :function create-activate-fn})
                         create-hello-script? (conj {:label (menu-label-with-icon


### PR DESCRIPTION
Prefixing `activate.cljs` files with the respective ”section”, so `user_activate.cljs` and `workspace_activate.cljs`. Also reverting the temporary rename of the symbols in these files, as they no longer conflict/compete.

Fixes #73