### PR TITLE
Add missing `promesa.protocols` namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Joyride
 
 ## [Unreleased]
 
+- Fix: [v0.0.16 is broken, no script using `promesa.protocols` works](https://github.com/BetterThanTomorrow/joyride/issues/85)
+
 ## [0.0.16] - 2022-08-16
 
 - [Include `cljs.test`](https://github.com/BetterThanTomorrow/joyride/issues/76)

--- a/src/joyride/sci.cljs
+++ b/src/joyride/sci.cljs
@@ -61,6 +61,7 @@
                         :allow :all}
               :namespaces {'cljs.test cljs-test-config/cljs-test-namespace
                            'promesa.core promesa-config/promesa-namespace
+                           'promesa.protocols promesa-config/promesa-protocols-namespace
                            'joyride.core
                            {'*file* sci/file
                             'extension-context (sci/copy-var db/extension-context joyride-ns)


### PR DESCRIPTION
We were missing to add `promesa.protocols` to the builtin namespaces.

Fixes #85