### PR TITLE
Dispose disposables before discarding them.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Joyride
 
 ## [Unreleased]
+- Fix: [Not disposing of disposables on dev reload](https://github.com/BetterThanTomorrow/joyride/issues/87)
 
 ## [0.0.17] - 2022-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Joyride
 
 ## [Unreleased]
+
 - Fix: [Not disposing of disposables on dev reload](https://github.com/BetterThanTomorrow/joyride/issues/87)
 
 ## [0.0.17] - 2022-08-17

--- a/src/joyride/extension.cljs
+++ b/src/joyride/extension.cljs
@@ -16,10 +16,10 @@
     (.push (.-subscriptions context) disposable)))
 
 (defn- clear-disposables! []
-  (swap! db/!app-db assoc :disposables [])
-  (p/run! (fn [^js disposable]
+  (run! (fn [^js disposable]
             (.dispose disposable))
-          (:disposables @db/!app-db)))
+          (:disposables @db/!app-db))
+  (swap! db/!app-db assoc :disposables []))
 
 (defn run-code
   ([]


### PR DESCRIPTION
On dev reload, correctly call `dispose` method of each disposable
before resetting the vector of stored disposables. Fixes #87
