### PR TITLE
Add configuration for nrepl port address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes to Joyride
 
 ## [Unreleased]
 
+- [Make nREPL host address configurable](https://github.com/BetterThanTomorrow/joyride/issues/102)
 - Fix: [Run Workspace Script and Run User Script has the same default keybindings](https://github.com/BetterThanTomorrow/joyride/issues/100)
 
 ## [0.0.21] - 2022-10-22

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ Joyride installs a "regular” User script as well. You can run either of these 
 
 While developing Joyride scripts you should of course do it leveraging Interactive Programming (see [this video](https://www.youtube.com/watch?v=d0K1oaFGvuQ) demonstrating it).
 
-### nRepl Server
+### nREPL Server
 
-Joyride has an [nRepl](https://nrepl.org) server and commands for starting and stopping it. By default, the server will be bound to `127.0.0.1` on an available port. The host address can be configured via the setting `joyride.nReplHostAddress`. Then connect your nREPl client (Calva, Clojure CLI, or whatever.)
+Joyride has an [nREPL](https://nrepl.org) server and commands for starting and stopping it. By default, the server will be bound to `127.0.0.1` on an available port. The host address can be configured via the setting `joyride.nreplHostAddress`. Then connect your nREPl client (Calva, Clojure CLI, or whatever.)
 
-Speaking of Calva. It has a command for starting the Joyride nRepl server and connect to it in one go. This video demonstrates starting from scratch, including installing Joyride.
+Speaking of Calva. It has a command for starting the Joyride nREPL server and connect to it in one go. This video demonstrates starting from scratch, including installing Joyride.
 
 https://user-images.githubusercontent.com/30010/167246562-24638f12-120b-48e9-893a-7408d5beeb77.mp4
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Making VS Code Hackable
 
-Modify your editor by executing ClojureScript code in your REPL and/or run scripts via keyboard shortcuts you choose. The Visual Studio Code API, as well as the APIs of its extensions, are at your command!
+Modify your editor while it is running by executing ClojureScript code via the Joyride REPL and/or run scripts via keyboard shortcuts you choose. The Visual Studio Code API, as well as the APIs of its extensions, are at your command!
 
 https://user-images.githubusercontent.com/30010/165934412-ffeb5729-07be-4aa5-b291-ad991d2f9f6c.mp4
 
@@ -9,10 +9,6 @@ https://user-images.githubusercontent.com/30010/165934412-ffeb5729-07be-4aa5-b29
 Joyride is Powered by [SCI](https://github.com/babashka/sci) (Small Clojure Interpreter).
 
 See [doc/api.md](https://github.com/BetterThanTomorrow/joyride/blob/master/doc/api.md) for documentation about the Joyride API.
-
-## WIP
-
-You are entering a construction yard. Things are going to change and break your configs while we are searching for good APIs and UI/Ux.
 
 Your feedback is highly welcome!
 
@@ -51,7 +47,13 @@ Joyride installs a "regular” User script as well. You can run either of these 
 
 ## Quick Start - Start the REPL
 
-While developing Joyride scripts you should of course do it leveraging Interactive Programming (see [this video](https://www.youtube.com/watch?v=d0K1oaFGvuQ) demonstrating it). With Calva it is very quick to start a Joyride REPL and connect Calva to it. This video demonstrates starting from scratch, including installing Joyride.
+While developing Joyride scripts you should of course do it leveraging Interactive Programming (see [this video](https://www.youtube.com/watch?v=d0K1oaFGvuQ) demonstrating it).
+
+### nRepl Server
+
+Joyride has an [nRepl](https://nrepl.org) server and commands for starting and stopping it. By default, the server will be bound to `127.0.0.1` on an available port. The host address can be configured via the setting `joyride.nReplHostAddress`. Then connect your nREPl client (Calva, Clojure CLI, or whatever.)
+
+Speaking of Calva. It has a command for starting the Joyride nRepl server and connect to it in one go. This video demonstrates starting from scratch, including installing Joyride.
 
 https://user-images.githubusercontent.com/30010/167246562-24638f12-120b-48e9-893a-7408d5beeb77.mp4
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -2,7 +2,7 @@
 
 VS Code settings to configure Joyride.
 
-* `joyride.nReplHostAddress`, the host address to bind the nRepl server to
+* `joyride.nreplHostAddress`, the host address to bind the nREPL server to
 
 ## User and Workspace scripts
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -2,9 +2,11 @@
 
 VS Code settings to configure Joyride.
 
-There is no configuration. 😀
+* `joyride.nReplHostAddress`, the host address to bind the nRepl server to
 
-There are some conventions, though. Joyride looks for scripts in:
+## User and Workspace scripts
+
+Joyride looks for scripts in:
 
 * User scripts: `<user home>/.config/joyride/scripts/**/*.cljs`
 * Workspace scripts: `.joyride/scripts/**/*.cljs`
@@ -13,6 +15,8 @@ The scripts are displayed in menus accessible via the commands:
 
 * **Joyride: Run User Script**, default keybinding `ctrl+shift+,`
 * **Joyride: Run Workspace Script**, default keybinding `ctrl+shift+.`
+
+## Keyboard shortcuts
 
 You can configure keyboard shortcuts to the commands `joyride.runUserScript`, and `joyride.runWorkspaceScript` giving them a script as an argument.
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
       {
         "title": "Joyride",
         "properties": {
-          "joyride.nReplHostAddress": {
+          "joyride.nreplHostAddress": {
             "type": "string",
             "default": "127.0.0.1",
             "markdownDescription": "The host address to use for the nREPL server."

--- a/package.json
+++ b/package.json
@@ -53,6 +53,18 @@
   ],
   "main": "./extension.js",
   "contributes": {
+    "configuration":[
+      {
+        "title": "Joyride",
+        "properties": {
+          "joyride.nReplHostAddress": {
+            "type": "string",
+            "default": "127.0.0.1",
+            "markdownDescription": "The host address to use for the nREPL server."
+          }
+        }
+      }
+    ],
     "commands": [
       {
         "command": "joyride.runCode",

--- a/src/joyride/extension.cljs
+++ b/src/joyride/extension.cljs
@@ -61,7 +61,6 @@
 
   (let [{:keys [extension-context]} @db/!app-db]
     (register-command! extension-context "joyride.runCode" #'run-code+)
-    #_(register-command! extension-context "joyride.runSelectedCode" #'run-selected-code+)
     (register-command! extension-context "joyride.runWorkspaceScript" #'scripts-handler/run-workspace-script+)
     (register-command! extension-context "joyride.runUserScript" #'scripts-handler/run-user-script+)
     (register-command! extension-context "joyride.openWorkspaceScript" #'scripts-handler/open-workspace-script+)

--- a/src/joyride/extension.cljs
+++ b/src/joyride/extension.cljs
@@ -61,6 +61,7 @@
 
   (let [{:keys [extension-context]} @db/!app-db]
     (register-command! extension-context "joyride.runCode" #'run-code+)
+    #_(register-command! extension-context "joyride.runSelectedCode" #'run-selected-code+)
     (register-command! extension-context "joyride.runWorkspaceScript" #'scripts-handler/run-workspace-script+)
     (register-command! extension-context "joyride.runUserScript" #'scripts-handler/run-user-script+)
     (register-command! extension-context "joyride.openWorkspaceScript" #'scripts-handler/open-workspace-script+)

--- a/src/joyride/nrepl.cljs
+++ b/src/joyride/nrepl.cljs
@@ -9,7 +9,7 @@
    [joyride.when-contexts :as when-contexts]
    [joyride.repl-utils :as repl-utils :refer [the-sci-ns]]
    [joyride.sci :as jsci]
-   [joyride.utils :refer [info warn cljify]]
+   [joyride.utils :refer [info warn error cljify]]
    [promesa.core :as p]
    [sci.core :as sci]
    [clojure.pprint :as pp]))
@@ -250,26 +250,36 @@
 
     (p/create
      (fn [resolve _reject]
-       (let [server (node-net/createServer
-                     (partial on-connect {:sci-ctx-atom ctx-atom}))]
-         (swap! !db assoc ::server server)
-         (p/do
-           (when-contexts/set-context! ::when-contexts/joyride.isNReplServerRunning true))
-         (.listen server
-                  port
-                  "127.0.0.1" ;; default for now
-                  (fn []
-                    (let [addr (-> server (.address))
-                          port (-> addr .-port)
-                          host (-> addr .-address)]
-                      (info "nREPL server started on port" port "on host"
-                            (str host "- nrepl://" host ":" port))
-                      (-> (vscode/workspace.fs.writeFile (port-file-uri root-path)
-                                                         (-> (new js/TextEncoder) (.encode (str port))))
-                          (p/handle (fn [_result error]
-                                      (resolve port)
-                                      (when error
-                                        (info "Could not write port file" error)))))))))))))
+       (let [nrepl-host-address (-> (vscode/workspace.getConfiguration "joyride")
+                                    (.get "nReplHostAddress"))]
+         (if (< 0 (node-net/isIP nrepl-host-address))
+           (let [server (node-net/createServer
+                         (partial on-connect {:sci-ctx-atom ctx-atom}))]
+             (swap! !db assoc ::server server)
+             (p/do
+               (when-contexts/set-context! ::when-contexts/joyride.isNReplServerRunning true))
+             (.listen server
+                      port
+                      nrepl-host-address
+                      (fn []
+                        (let [addr (-> server (.address))
+                              port (-> addr .-port)
+                              host (-> addr .-address)]
+                          (info "nREPL server started on port" port "on host"
+                                (str host "- nrepl://" host ":" port))
+                          (-> (vscode/workspace.fs.writeFile
+                               (port-file-uri root-path)
+                               (-> (new js/TextEncoder) (.encode (str port))))
+                              (p/handle (fn [_result error]
+                                          (resolve port)
+                                          (when error
+                                            (warn "Could not write port file" error))))))))
+             (.on server "error"
+                  (fn [e]
+                    (when-contexts/set-context! ::when-contexts/joyride.isNReplServerRunning false)
+                    (.close server)
+                    (error "Problems with the nRepl server connection:" e))))
+           (error "Invalid host address, check setting `joyride.nReplHostAddress`")))))))
 
 (defn start-server+ [opts]
   (if-not (server-running?)

--- a/src/joyride/nrepl.cljs
+++ b/src/joyride/nrepl.cljs
@@ -225,7 +225,7 @@
   (when-contexts/context ::when-contexts/joyride.isNReplServerRunning))
 
 (defn- start-server'+
-  "Start nRepl server. Accepts options either as JS object or Clojure map."
+  "Start nREPL server. Accepts options either as JS object or Clojure map."
   [js-or-clj-opts]
   (let [opts (cljify js-or-clj-opts)
         port (or (:port opts)
@@ -251,7 +251,7 @@
     (p/create
      (fn [resolve _reject]
        (let [nrepl-host-address (-> (vscode/workspace.getConfiguration "joyride")
-                                    (.get "nReplHostAddress"))]
+                                    (.get "nreplHostAddress"))]
          (if (< 0 (node-net/isIP nrepl-host-address))
            (let [server (node-net/createServer
                          (partial on-connect {:sci-ctx-atom ctx-atom}))]
@@ -278,8 +278,8 @@
                   (fn [e]
                     (when-contexts/set-context! ::when-contexts/joyride.isNReplServerRunning false)
                     (.close server)
-                    (error "Problems with the nRepl server connection:" e))))
-           (error "Invalid host address, check setting `joyride.nReplHostAddress`")))))))
+                    (error "Problems with the nREPL server connection:" e))))
+           (error "Invalid host address, check setting `joyride.nreplHostAddress`")))))))
 
 (defn start-server+ [opts]
   (if-not (server-running?)


### PR DESCRIPTION
Add a setting `joyride.nReplHostAddress` with a default of `"127.0.0.1"`.

Fixes #102

The error handling is a bit lacking. Not sure how it is supposed to be done. But I added a listener for the `error` event and also sanity check the host address provided.