### PR TITLE
Change default keyboard shortcut bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ Changes to Joyride
 ## [Unreleased]
 
 - [Make nREPL host address configurable](https://github.com/BetterThanTomorrow/joyride/issues/102)
-- Fix: [Run Workspace Script and Run User Script has the same default keybindings](https://github.com/BetterThanTomorrow/joyride/issues/100)
+- New default keyboard shortcut bindings:
+  - `joyride.runCode`: `ctrl+alt+j space`
+  - `joyride.runUserScript`: `ctrl+alt+j u`
+  - `joyride.runWorkspaceScript`: `ctrl+alt+j w`
+  - Fixes: [Default key bindings for running scripts are weird on Swedish keyboard layouts](https://github.com/BetterThanTomorrow/joyride/issues/104)
+  - Fixes: [Run Workspace Script and Run User Script has the same default keybindings](https://github.com/BetterThanTomorrow/joyride/issues/100)
 
 ## [0.0.21] - 2022-10-22
 

--- a/package.json
+++ b/package.json
@@ -117,15 +117,15 @@
     "keybindings": [
       {
         "command": "joyride.runCode",
-        "key": "ctrl+shift+alt+space"
+        "key": "ctrl+alt+j space"
       },
       {
         "command": "joyride.runUserScript",
-        "key": "ctrl+shift+."
+        "key": "ctrl+alt+j u"
       },
       {
         "command": "joyride.runWorkspaceScript",
-        "key": "ctrl+shift+,"
+        "key": "ctrl+alt+j w"
       }
     ]
   },


### PR DESCRIPTION
The shortcuts were weird. And behaved weirdly with some keyboard layouts. I've changed them. They are all starting with `ctrl+alt+j` now. Should be easy to remember, I hope.