### PR TITLE
Use pprint/write instead of pprint/pprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Joyride
 
 ## [Unreleased]
 
+- Fix: [The nREPL server adds an extra newline to pretty printed results](https://github.com/BetterThanTomorrow/joyride/issues/108)
+
 ## [0.0.23] - 2022-11-22
 
 - [Add ”Evaluate Selection” command](https://github.com/BetterThanTomorrow/joyride/issues/106)

--- a/src/joyride/nrepl.cljs
+++ b/src/joyride/nrepl.cljs
@@ -4,7 +4,6 @@
    ["net" :as node-net]
    ["path" :as path]
    ["vscode" :as vscode]
-   [clojure.string :as str]
    [joyride.bencode :refer [encode decode-all]]
    [joyride.when-contexts :as when-contexts]
    [joyride.repl-utils :as repl-utils :refer [the-sci-ns]]
@@ -12,7 +11,8 @@
    [joyride.utils :refer [info warn error cljify]]
    [promesa.core :as p]
    [sci.core :as sci]
-   [clojure.pprint :as pp]))
+   [clojure.pprint :as pp]
+   [clojure.string :as string]))
 
 (defonce !db (atom {::log-messages? false
                     ::server nil
@@ -67,21 +67,22 @@
             "status" ["done"]}))
 
 (def pretty-print-fns-map
-  {"clojure.core/prn" prn
-   "clojure.pprint/pprint" pp/pprint
-   "cljs.pprint/pprint" pp/pprint
-   "cider.nrepl.pprint/pprint" pp/pprint})
+  {"clojure.core/pr" pr
+   "clojure.core/prn" prn
+   "clojure.pprint/pprint" pp/write
+   "cljs.pprint/pprint" pp/write
+   "cider.nrepl.pprint/pprint" pp/write})
 
 (defn format-value [nrepl-pprint pprint-options value]
   (if nrepl-pprint
-    (if-let [pprint-fn (pretty-print-fns-map nrepl-pprint)]
+    (if-let [pprint-fn (pretty-print-fns-map nrepl-pprint)] 
       (let [{:keys [right-margin length level]} pprint-options]
         (binding [*print-length* length
                   *print-level* level
                   pp/*print-right-margin* right-margin]
           (with-out-str (pprint-fn value))))
       (do
-        (debug "Pretty-Printing is only supported for clojure.core/prn and clojure.pprint/pprint.")
+        (debug "Pretty-Printing is only supported for clojure.core/pr[n] and clojure.pprint/pprint.")
         (pr-str value)))
     (pr-str value)))
 
@@ -199,7 +200,7 @@
                           s)
                         data)
                  [requests unprocessed] (decode-all data :keywordize-keys true)]
-             (when (not (str/blank? unprocessed))
+             (when (not (string/blank? unprocessed))
                (reset! pending unprocessed))
              (doseq [request requests]
                (handler request response-handler))))))

--- a/src/joyride/nrepl.cljs
+++ b/src/joyride/nrepl.cljs
@@ -67,11 +67,7 @@
             "status" ["done"]}))
 
 (def pretty-print-fns-map
-  {"clojure.core/pr" pr
-   "clojure.core/prn" prn
-   "clojure.pprint/pprint" pp/write
-   "cljs.pprint/pprint" pp/write
-   "cider.nrepl.pprint/pprint" pp/write})
+  {"cider.nrepl.pprint/pprint" pp/write})
 
 (defn format-value [nrepl-pprint pprint-options value]
   (if nrepl-pprint
@@ -82,7 +78,7 @@
                   pp/*print-right-margin* right-margin]
           (with-out-str (pprint-fn value))))
       (do
-        (debug "Pretty-Printing is only supported for clojure.core/pr[n] and clojure.pprint/pprint.")
+        (debug "Pretty-Printing is only supported for cider.nrepl.pprint/pprint")
         (pr-str value)))
     (pr-str value)))
 


### PR DESCRIPTION
The Clojure/Java nrepl server uses a wrapper around `pprint/write` when pretty printing. Thinking we can do as well, except I didn't see a need for wrapping.

Also adding `clojure.core/pr` as a pretty print function.

Fixes:
* #108