### PR TITLE
Add tap>, add-tap, remove-tap to sci config

### DIFF
--- a/src/joyride/sci.cljs
+++ b/src/joyride/sci.cljs
@@ -75,7 +75,10 @@
   (volatile!
    (sci/init {:classes {'js goog/global
                         :allow :all}
-              :namespaces {'clojure.core {'IFn (sci/copy-var IFn core-namespace)}
+              :namespaces {'clojure.core {'IFn (sci/copy-var IFn core-namespace)
+                                          'tap> (sci/copy-var tap> core-namespace)
+                                          'add-tap (sci/copy-var remove-tap core-namespace)
+                                          'remove-tap (sci/copy-var remove-tap core-namespace)}
                            'clojure.zip zip-namespace
                            'cljs.test cljs-test-config/cljs-test-namespace
                            'promesa.core promesa-config/promesa-namespace


### PR DESCRIPTION
Attempts to address #112 by copying `tap>`, `add-tap` and `remove-tap` into the core namespace with SCI. This makes the symbols available, but fails provide expected tap functionality.

Before:
```clojure
user => tap>
; Could not resolve symbol: tap>

user => add-tap
; Could not resolve symbol: add-tap

user => remove-tap
; Could not resolve symbol: remove-tap
```

After:
```clojure
user => (add-tap prn)
nil

user => (tap> :foo)
;; should print `:foo` here ❗
true

user => (remove-tap prn)
nil

