### PR TITLE
Invalidate require cache when requiring js files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Joyride
 ## [Unreleased]
 
 - [Add `src` sub User and Workspace directories to the classpath](https://github.com/BetterThanTomorrow/joyride/issues/115)
+- [Feature request: Enable requiring JavaScript files](https://github.com/BetterThanTomorrow/joyride/issues/117)
 
 ## [0.0.26] - 2022-11-28
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ https://user-images.githubusercontent.com/30010/165934412-ffeb5729-07be-4aa5-b29
 
 Joyride is Powered by [SCI](https://github.com/babashka/sci) (Small Clojure Interpreter).
 
+The default language of Joyride is [Clojure](https://clojure.org), but you can also use JavaScript for hacking your VS Code environment.
+
 See [doc/api.md](https://github.com/BetterThanTomorrow/joyride/blob/master/doc/api.md) for documentation about the Joyride API.
 
 Your feedback is highly welcome!

--- a/doc/api.md
+++ b/doc/api.md
@@ -105,7 +105,15 @@ Look at the [Activation example](../examples/.joyride/scripts/activate.cljs) scr
 
 ### NPM modules
 
-TBD.
+To use npm modules these need to be installed in the path somewhere in the path from where the script using it resides, to the root of the filessystem. Consider using `<user-home>/.config/joyride` and `<ws-root>/.joyride`. (`yarn` or `npm i` both work, Joyride doesn't care, it looks for stuff in `node_modules`).
+
+See [examples/.joyride/scripts/html_to_hiccup.cljs](examples/.joyride/scripts/html_to_hiccup.cljs) for an example.
+
+The modules you use need to be in CommonJS format.
+
+### JavaScript files
+
+You can require JavaScript files (CommonJS) from your scripts by using absolute or relative paths to the JS files. The code in these files are reloaded when you re-require them from Clojure code. See [Examples Requiring JavaScript Files](../examples/README.md#requiring-javascript-files) for an example.
 
 ### VS Code, and Extension ”namespaces”
 

--- a/examples/.joyride/scripts/require_js_file.cljs
+++ b/examples/.joyride/scripts/require_js_file.cljs
@@ -1,0 +1,17 @@
+(ns require-js-file
+  (:require ["../src/hello-world.js" :as hello-world]
+            ;; You can use absolute paths as well.
+            #_["/Users/pez/Projects/joyride/examples/.joyride/src/hello-world.js" :as absolute-hw]))
+
+;; Run this as a Workspace Script or load it in the REPL.
+
+(comment
+  (hello-world/hello)
+  #_(absolute-hw/hello)
+  :rcf)
+
+(hello-world/showHelloMessage)
+
+;; Then update `../src/hello-world.js` and run the script again.
+;; Or, if you are connected to the REPL, reload the file
+;;   or evaluate the `ns` form, and then evalute the hello forms

--- a/examples/.joyride/src/hello-world.js
+++ b/examples/.joyride/src/hello-world.js
@@ -1,0 +1,18 @@
+const vscode = require("vscode");
+
+exports.hello = () => {
+  return "Hello World!";
+};
+
+exports.showHelloMessage = async () => {
+  const button = await vscode.window.showInformationMessage("Hello World!", "Cancel", "OK");
+  if (button === "OK") {
+    vscode.window.showInformationMessage("You clicked OK! Try clicking Cancel too?.");
+  } else {
+    const name = await vscode.window.showInputBox({
+      title: "CIA wants to know",
+      prompt: "What is your name?",
+    });
+    vscode.window.showInformationMessage(`Hello ${name}!`);
+  }
+};

--- a/examples/README.md
+++ b/examples/README.md
@@ -192,6 +192,21 @@ The [.joyride/scripts/ws.cljs](.joyride/scripts/ws.cljs) script shows two things
 
 Both examples use a utility script: [.joyride/src/util/workspace.cljs](.joyride/src/util/workspace.cljs)
 
+### requiring JavaScript files
+
+You can use code written in JavaScript (or compiled to JavaScript) with Joyride by using absolute or relative paths to these scripts in your requires.
+
+[.joyride/scripts/require_js_file.cljs](.joyride/scripts/require_js_file.cljs) does this, using an ns-form require that looks like so:
+
+```clojure
+(ns require-js-file
+  (:require ["../src/hello-world.js" :as hello-world]))
+```
+
+It can then use the exports from [.joyride/src/hello-world.js](.joyride/src/hello-world.js).
+
+This means you can write your scripts using JavaScript if you like, using only a small glue script written in Clojure, that require the JS code. The JavaScript code is reloaded when you run the Clojure glue script, so you can even enjoy some interactive programming this way. (Or a lot, if you utilize Clojure a bit more than just relaying over to a JavaScript script.)
+
 ### npm packages
 
 You can use packages from `npm` in your Joyride scripts. There's an example of this, using [posthtml-parser](https://github.com/posthtml/posthtml-parser) in 

--- a/src/joyride/sci.cljs
+++ b/src/joyride/sci.cljs
@@ -64,6 +64,10 @@
 
 (defn require* [from-script lib]
   (let [req (module/createRequire (path/resolve (or from-script "./script.cljs")))
+        lib-path (if (path/isAbsolute lib) 
+                   lib
+                   (path/resolve (path/dirname from-script) lib))
+        _ (aset (.-cache req) lib-path js/undefined)
         resolved (.resolve req lib)]
     (js/require resolved)))
 


### PR DESCRIPTION
I made it so that we invalidate the module require cache when a js file is required. Dunno if that is very inefficient? Is it OK for a first version of this, you think, @borkdude? Or is it fine, generally?