### PR TITLE
Add activation timing logging to the extension + scripts for comparing load times

### DIFF
--- a/script/bundle-compare.sh
+++ b/script/bundle-compare.sh
@@ -23,11 +23,11 @@ read -r ext1_size ext1_time <<< $(bundle_size_and_load_time "$extension1")
 read -r ext2_size ext2_time <<< $(bundle_size_and_load_time "$extension2")
 
 function report_size_and_load_time() {
-  printf "  1. %s\n     Size: %s bytes\n     Load time average: %.2f ms\n" "$1" "$2" "$3"
+  printf "  %d. %s\n     Size: %s bytes\n     Load time average: %.2f ms\n" "$1" "$2" "$3" "$4"
 }
 echo "Comparison of:"
-report_size_and_load_time "$extension1" "$ext1_size" "$ext1_time"
-report_size_and_load_time "$extension2" "$ext2_size" "$ext2_time"
+report_size_and_load_time 1 "$extension1" "$ext1_size" "$ext1_time"
+report_size_and_load_time 2 "$extension2" "$ext2_size" "$ext2_time"
 echo "Loaded the bundles $runs times each."
 
 size_diff=$(bc -le "$ext2_size - $ext1_size")

--- a/script/bundle-compare.sh
+++ b/script/bundle-compare.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Compare two joyride.js bundles, size and load time
+
+script_dir=$(dirname "$0")
+bundle_check_script="$script_dir/bundle-load-check.js"
+extension1=$1
+extension2=$2
+runs=${3:-10}
+
+# Check if both extensions exist
+if [ ! -d "$extension1" ] || [ ! -d "$extension2" ]; then
+  echo "Usage: bundle-compare.sh <extension-1-dir> <extension-2-dir> [runs]]"
+  echo "Both extension directories must exist."
+  exit 1
+fi
+
+function bundle_size_and_load_time() {
+  node "$bundle_check_script" "$1" "$runs" | awk '/bundle size/ { size=$4 } /average load time/ { time=$4 } END { print size " " time }'
+}
+
+read -r ext1_size ext1_time <<< $(bundle_size_and_load_time "$extension1")
+read -r ext2_size ext2_time <<< $(bundle_size_and_load_time "$extension2")
+
+function report_size_and_load_time() {
+  printf "  1. %s\n     Size: %s bytes\n     Load time average: %.2f ms\n" "$1" "$2" "$3"
+}
+echo "Comparison of:"
+report_size_and_load_time "$extension1" "$ext1_size" "$ext1_time"
+report_size_and_load_time "$extension2" "$ext2_size" "$ext2_time"
+echo "Loaded the bundles $runs times each."
+
+size_diff=$(bc -le "$ext2_size - $ext1_size")
+size_diff_percent=$(bc -le "scale=1; $size_diff * 100.0 / $ext1_size")
+echo "Size difference: $size_diff $4 ($size_diff_percent%)"
+
+time_diff=$(bc -le "scale=2; $ext2_time - $ext1_time")
+time_diff_percent=$(bc -le "scale=1; $time_diff * 100.0 / $ext1_time")
+echo "Load time difference: $time_diff $4 ($time_diff_percent%)"
+

--- a/script/bundle-load-check.js
+++ b/script/bundle-load-check.js
@@ -1,9 +1,11 @@
+// Reports on the the size and the time it takes to load the joyride.js bundle.
+
 const fs = require("fs");
 const path = require("path");
 
 const joyrideDir = process.argv[2];
 if (!joyrideDir) {
-  console.error("Usage: node load-time.js <joyride-extension-dir>");
+  console.error("Usage: node bundle-load-check.js <joyride-extension-dir> [runs]");
   process.exit(1);
 }
 const runs = process.argv[3] || 10;
@@ -13,6 +15,8 @@ if (!fs.existsSync(joyrideJs)) {
   console.error("joyride.js not found, exiting");
   process.exit(1);
 }
+const stats = fs.statSync(joyrideJs)
+console.log("joyride.js bundle size", stats.size, "bytes");  
 
 const mockVscodeNodeModulesSrcDir = path.join(__dirname, "mock-vscode/node_modules");
 const fakeVscodeNodeModulesDestDir = path.join(joyrideDir, '/out/node_modules');

--- a/script/load-time.js
+++ b/script/load-time.js
@@ -25,16 +25,40 @@ const end = performance.now();
 console.log("initial load joyride.js", end - start, "ms");
 delete require.cache[require.resolve(joyrideJs)];
 
-let totalTime = 0;
+let runTimes = [];
 for (let i = 0; i < runs; i++) {
   const start = performance.now();
   require(joyrideJs);
   const end = performance.now();
   const time = end - start;
   console.log("load joyride.js", time, "ms");
-  totalTime += time;
+  runTimes.push(time);
   delete require.cache[require.resolve(joyrideJs)];
 }
-console.log("average load time", totalTime / runs, "ms");
+console.log("average load time", averageRunTime(runTimes), "ms");
 
 fs.rmSync(fakeVscodeNodeModulesDestDir, { recursive: true });
+
+function averageRunTime(runTimes) {
+  if (runTimes.length === 0) {
+    return 0;
+  }
+
+  let sum = 0;
+  for (let i = 0; i < runTimes.length; i++) {
+    sum += runTimes[i];
+  }
+  let average = sum / runTimes.length;
+  let threshold = average * 1.5;
+
+  sum = 0;
+  let count = 0;
+  for (let i = 0; i < runTimes.length; i++) {
+    if (runTimes[i] < threshold) {
+      sum += runTimes[i];
+      count++;
+    }
+  }
+
+  return sum / count;
+}

--- a/script/load-time.js
+++ b/script/load-time.js
@@ -19,14 +19,18 @@ const fakeVscodeNodeModulesDestDir = path.join(joyrideDir, '/out/node_modules');
 
 fs.cpSync(mockVscodeNodeModulesSrcDir, fakeVscodeNodeModulesDestDir, { recursive: true });
 
+const start = performance.now();
 require(joyrideJs); // First require is slower
+const end = performance.now();
+console.log("initial load joyride.js", end - start, "ms");
 delete require.cache[require.resolve(joyrideJs)];
+
 let totalTime = 0;
 for (let i = 0; i < runs; i++) {
-  start = performance.now();
+  const start = performance.now();
   require(joyrideJs);
-  end = performance.now();
-  time = end - start;
+  const end = performance.now();
+  const time = end - start;
   console.log("load joyride.js", time, "ms");
   totalTime += time;
   delete require.cache[require.resolve(joyrideJs)];

--- a/script/mock-vscode/.gitignore
+++ b/script/mock-vscode/.gitignore
@@ -1,0 +1,1 @@
+!node_modules/

--- a/script/mock-vscode/node_modules/vscode/index.js
+++ b/script/mock-vscode/node_modules/vscode/index.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/src/joyride/extension.cljs
+++ b/src/joyride/extension.cljs
@@ -71,7 +71,8 @@
                  :runCode run-code+}))
 
 (defn ^:export activate [^js context]
-  (js/console.info "Joyride activate START")
+  (js/console.time "activation")
+  (js/console.timeLog "activation" "Joyride activate START")
   
   (when context
     (swap! db/!app-db assoc
@@ -105,7 +106,8 @@
                       (life-cycle/maybe-run-init-script+ scripts-handler/run-workspace-script+
                                                          (:workspace (life-cycle/init-scripts))))
                     (utils/sayln "🟢 Joyride VS Code with Clojure. 🚗💨"))))))
-    (js/console.info "Joyride activate END")
+    (js/console.timeLog "activation" "Joyride activate END")
+    (js/console.timeEnd "activation")
     api))
 
 (defn ^:export deactivate []


### PR DESCRIPTION
* Measuring the time it takes from start to end of extension `activate()`
* Added some utility scripts for comparing load times between bundles

Example run of a comparison:

```
% script/bundle-compare.sh /Users/pez/.vscode/extensions/betterthantomorrow.joyride-0.0.32 /Users/pez/Downloads/joyride-0.0.33-rewrite-clj-77ebb270/extension 100
Comparison of:
  1. /Users/pez/.vscode/extensions/betterthantomorrow.joyride-0.0.32
     Size: 1351978 bytes
     Load time average: 48.33 ms
  2. /Users/pez/Downloads/joyride-0.0.33-rewrite-clj-77ebb270/extension
     Size: 1591118 bytes
     Load time average: 55.13 ms
Loaded the bundles 100 times each.
Size difference: 239140  (17.6%)
Load time difference: 6.806672046184534  (14.0%)
```

- [x] I have read the [developer documentation](https://github.com/BetterThanTomorrow/joyride/blob/master/CONTRIBUTE.md).

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/BetterThanTomorrow/joyride/tree/master/vscode-test-runner/workspace-1/.joyride/src/integration_test) to prevent against future regressions

- [ ] I have updated the **\[Unreleased\]** section of the [CHANGELOG.md](https://github.com/BetterThanTomorrow/joyride/blob/master/CHANGELOG.md) file with a link to the addressed issue.
