### PR TITLE
:memo: Fix broken link in examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Joyride Examples
 
-Demonstrating some ways to [Joyride VS Code](https://marketplace.visualstudio.com/items?itemName=betterthantomorrow.joyride). You'll find the examples in the [examples/.joyride](./examples/.joyride) folder of this repository.
+Demonstrating some ways to [Joyride VS Code](https://marketplace.visualstudio.com/items?itemName=betterthantomorrow.joyride). You'll find the examples in the [examples/.joyride](./.joyride) folder of this repository.
 
 See also: [Joyride @ London Clojurians, Nov 29 2022](https://github.com/PEZ/london-clojurians-joyride)
 


### PR DESCRIPTION
Just a documentation fix. The link for `examples/.joyride` was broken...it went to `examples/examples/.joyride` instead. Relative URLs can be confusing!

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/BetterThanTomorrow/joyride/blob/master/CONTRIBUTE.md).

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/BetterThanTomorrow/joyride/tree/master/vscode-test-runner/workspace-1/.joyride/src/integration_test) to prevent against future regressions

- [ ] I have updated the **\[Unreleased\]** section of the [CHANGELOG.md](https://github.com/BetterThanTomorrow/joyride/blob/master/CHANGELOG.md) file with a link to the addressed issue.
