### PR TITLE
Don't automatically create joyride workspace directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Joyride
 
 ## [Unreleased]
 
+- Fix: [Unwanted .joyride directory creation](https://github.com/BetterThanTomorrow/joyride/issues/174)
+
 ## [0.0.36] - 2023-11-19
 
 - Remove pop up message about .joyride/deps.edn being created/updated
@@ -14,7 +16,7 @@ Changes to Joyride
 
 ## [0.0.34] - 2023-11-17
 
-- [The nrepl server croaks on eval messages containing the `ns` field](https://github.com/BetterThanTomorrow/joyride/issues/171)
+- Fix: [The nrepl server croaks on eval messages containing the `ns` field](https://github.com/BetterThanTomorrow/joyride/issues/171)
 
 ## [0.0.33] - 2023-02-12
 

--- a/src/joyride/extension.cljs
+++ b/src/joyride/extension.cljs
@@ -96,7 +96,7 @@
     (when context
       (-> (p/do
             (getting-started/maybe-create-user-content+)
-            (getting-started/maybe-create-workspace-content+))
+            (getting-started/maybe-create-workspace-config+ false))
           (p/catch
            (fn [e]
              (js/console.error "Joyride activate error" e)))

--- a/src/joyride/getting_started.cljs
+++ b/src/joyride/getting_started.cljs
@@ -54,12 +54,14 @@
           _ (vscode/workspace.fs.writeFile deps-uri new-buffer)]
     deps-uri))
 
-(defn maybe-create-workspace-content+ []
-  (p/let [deps-uri (path->uri (conf/workspace-abs-joyride-path) ["deps.edn"])
-          created?+ (maybe-create-content+ (getting-started-content-uri ["workspace" "deps.edn"])
-                                          deps-uri)]
-    (when created?+
-      (update-workspace-deps+ deps-uri))))
+(defn maybe-create-workspace-config+ [create-joyride-dir?]
+  (p/let [joyride-dir-exists?+ (utils/path-or-uri-exists?+ (path->uri (conf/workspace-abs-joyride-path) "."))]
+    (when (or joyride-dir-exists?+ create-joyride-dir?)
+      (p/let [deps-uri (path->uri (conf/workspace-abs-joyride-path) ["deps.edn"])
+              created?+ (maybe-create-content+ (getting-started-content-uri ["workspace" "deps.edn"])
+                                               deps-uri)]
+        (when created?+
+          (update-workspace-deps+ deps-uri))))))
 
 (defn create-and-open-content-file+ [source destination]
   (fn []
@@ -74,9 +76,13 @@
       (create-and-open-content-file+ source destination))))
 
 (defn maybe-create-workspace-activate-fn+ []
-  (maybe-create-and-open-content+ (getting-started-content-uri ["workspace" "scripts" "workspace_activate.cljs"])
-                                  (path->uri (conf/workspace-abs-scripts-path) ["workspace_activate.cljs"])))
+  (p/do
+    (maybe-create-workspace-config+ true)
+    (maybe-create-and-open-content+ (getting-started-content-uri ["workspace" "scripts" "workspace_activate.cljs"])
+                                    (path->uri (conf/workspace-abs-scripts-path) ["workspace_activate.cljs"]))))
 
 (defn maybe-create-workspace-hello-fn+ []
-  (maybe-create-and-open-content+ (getting-started-content-uri ["workspace" "scripts" "hello_joyride_workspace_script.cljs"])
-                                  (path->uri (conf/workspace-abs-scripts-path) ["hello_joyride_workspace_script.cljs"])))
+  (p/do
+    (maybe-create-workspace-config+ true)
+    (maybe-create-and-open-content+ (getting-started-content-uri ["workspace" "scripts" "hello_joyride_workspace_script.cljs"])
+                                    (path->uri (conf/workspace-abs-scripts-path) ["hello_joyride_workspace_script.cljs"]))))


### PR DESCRIPTION
1. On startup, I added a check for if the `.joyride` directory exist and we only create the `.joyride/deps.edn` config if so.
2. When creating workspace content via the Joyride commands for this, we already create the .joyride directory if it doesn't exist, so here we now also go ahead and create the `deps.edn` config.

* Fixes #174


- [x] I have read the [developer documentation](https://github.com/BetterThanTomorrow/joyride/blob/master/CONTRIBUTE.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/BetterThanTomorrow/joyride/tree/master/vscode-test-runner/workspace-1/.joyride/src/integration_test) to prevent against future regressions

- [x] I have updated the **\[Unreleased\]** section of the [CHANGELOG.md](https://github.com/BetterThanTomorrow/joyride/blob/master/CHANGELOG.md) file with a link to the addressed issue.
