### PR TITLE
User deps revert

### DIFF
--- a/.joyride/deps.edn
+++ b/.joyride/deps.edn
@@ -1,13 +1,11 @@
 ;; clojure-lsp needs this config to analyze Joyride code
-;; To tell clojure-lsp about this file:
-;; 1. Add a source-alias to `.lsp/config.edn`. Minimal config file content:
-;;    {:source-aliases #{:joyride}}
-;; 2. Add a `:joyride` alias to the project root deps.edn file.
-;;    Minimal file content:
-;;    {:aliases {:joyride {:extra-deps {joyride/workspace {:local/root ".joyride"}}}}}
-
+;; To get clojure-lsp to find this file:
+;; 1. add a `:joyride-user` `:source-alias` to `.lsp/config.edn`
+;; 2. add `:joyride-user` to `:aliases` in your global/user `deps.edn`.
+;;    content something like so:
+;;    :joyride-user {:extra-deps {joyride/user {:local/root "/Users/pez/.config/joyride"}}}
+;;                                                           ^ your user Joyride directory
 {:deps {org.clojure/clojurescript {:mvn/version "1.11.54"}
         funcool/promesa {:mvn/version "9.0.471"}
-        rewrite-clj/rewrite-clj {:mvn/version "1.1.46"}
-        joyride/user {:local/root "/Users/pez/.config/joyride"}}
+        rewrite-clj/rewrite-clj {:mvn/version "1.1.46"}}
  :paths ["src" "scripts"]}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Joyride
 
 ## [Unreleased]
 
+- Fix: [The `:joyride/user` workspace deps.edn only works for one user](https://github.com/BetterThanTomorrow/joyride/issues/176)
+
 ## [0.0.37] - 2023-11-20
 
 - Fix: [Unwanted .joyride directory creation](https://github.com/BetterThanTomorrow/joyride/issues/174)

--- a/assets/getting-started-content/user/deps.edn
+++ b/assets/getting-started-content/user/deps.edn
@@ -1,4 +1,10 @@
 ;; clojure-lsp needs this config to analyze Joyride code
+;; To get clojure-lsp to find this file:
+;; 1. add a `:joyride-user` `:source-alias` to `.lsp/config.edn`
+;; 2. add `:joyride-user` to `:aliases` in your global/user `deps.edn`.
+;;    content something like so:
+;;    :joyride-user {:extra-deps {joyride/user {:local/root "/Users/pez/.config/joyride"}}}
+;;                                                           ^ your user Joyride directory
 {:deps {org.clojure/clojurescript {:mvn/version "1.11.54"}
         funcool/promesa {:mvn/version "9.0.471"}
         rewrite-clj/rewrite-clj {:mvn/version "1.1.46"}}

--- a/assets/getting-started-content/workspace/deps.edn
+++ b/assets/getting-started-content/workspace/deps.edn
@@ -5,9 +5,11 @@
 ;; 2. Add a `:joyride` alias to the project root deps.edn file.
 ;;    Minimal file content:
 ;;    {:aliases {:joyride {:extra-deps {joyride/workspace {:local/root ".joyride"}}}}}
-
+;;
+;; To also tell clojure-lsp about your Joyride user scripts, see instructions
+;; in your User Joyride config directory `deps.edn` file.
+;; (`~/.config/joyride/deps.edn` on Mac/Linux, somewhere similar on Windows?)
 {:deps {org.clojure/clojurescript {:mvn/version "1.11.54"}
         funcool/promesa {:mvn/version "9.0.471"}
-        rewrite-clj/rewrite-clj {:mvn/version "1.1.46"}
-        joyride/user {:local/root "-JOYRIDE-USER-CONFIG-PATH-"}}
+        rewrite-clj/rewrite-clj {:mvn/version "1.1.46"}}
  :paths ["src" "scripts"]}

--- a/examples/.clj-kondo/funcool/promesa/config.edn
+++ b/examples/.clj-kondo/funcool/promesa/config.edn
@@ -5,4 +5,5 @@
            promesa.core/plet        clojure.core/let
            promesa.core/loop        clojure.core/loop
            promesa.core/recur       clojure.core/recur
-           promesa.core/with-redefs clojure.core/with-redefs}}
+           promesa.core/with-redefs clojure.core/with-redefs
+           promesa.core/doseq       clojure.core/doseq}}

--- a/examples/.clj-kondo/rewrite-clj/rewrite-clj/config.edn
+++ b/examples/.clj-kondo/rewrite-clj/rewrite-clj/config.edn
@@ -1,0 +1,5 @@
+{:lint-as
+ {rewrite-clj.zip/subedit-> clojure.core/->
+  rewrite-clj.zip/subedit->> clojure.core/->>
+  rewrite-clj.zip/edit-> clojure.core/->
+  rewrite-clj.zip/edit->> clojure.core/->>}}

--- a/examples/.joyride/deps.edn
+++ b/examples/.joyride/deps.edn
@@ -1,0 +1,15 @@
+;; clojure-lsp needs this config to analyze Joyride code
+;; To tell clojure-lsp about this file:
+;; 1. Add a source-alias to `.lsp/config.edn`. Minimal config file content:
+;;    {:source-aliases #{:joyride}}
+;; 2. Add a `:joyride` alias to the project root deps.edn file.
+;;    Minimal file content:
+;;    {:aliases {:joyride {:extra-deps {joyride/workspace {:local/root ".joyride"}}}}}
+;;
+;; To also tell clojure-lsp about your Joyride user scripts, see instructions
+;; in your User Joyride config directory `deps.edn` file.
+;; (`~/.config/joyride/deps.edn` on Mac/Linux, somewhere similar on Windows?)
+{:deps {org.clojure/clojurescript {:mvn/version "1.11.54"}
+        funcool/promesa {:mvn/version "9.0.471"}
+        rewrite-clj/rewrite-clj {:mvn/version "1.1.46"}}
+ :paths ["src" "scripts"]}

--- a/examples/.lsp/config.edn
+++ b/examples/.lsp/config.edn
@@ -1,1 +1,1 @@
-{:source-paths #{".joyride/scripts"}}
+{:source-aliases #{:joyride :joyride-user}}

--- a/examples/deps.edn
+++ b/examples/deps.edn
@@ -1,1 +1,1 @@
-{}
+{:aliases {:joyride {:extra-deps {joyride/workspace {:local/root ".joyride"}}}}}

--- a/src/joyride/getting_started.cljs
+++ b/src/joyride/getting_started.cljs
@@ -44,24 +44,13 @@
       (maybe-create-content+ (getting-started-content-uri ["user" "src" "my_lib.cljs"])
                              (path->uri (conf/user-abs-src-path) ["my_lib.cljs"])))))
 
-(defn- update-workspace-deps+ [deps-uri]
-  (js/console.info "Updating Workspace .joyride/deps.edn")
-  (p/let [buffer+ (vscode/workspace.fs.readFile deps-uri)
-          old-deps-content (-> (js/TextDecoder. "utf-8") (.decode buffer+))
-          user-path (-> (conf/user-abs-joyride-path) (string/escape {"\\" "\\\\"}))
-          new-deps-content (string/replace-first old-deps-content "-JOYRIDE-USER-CONFIG-PATH-" user-path)
-          new-buffer (-> (js/TextEncoder. "utf-8") (.encode new-deps-content))
-          _ (vscode/workspace.fs.writeFile deps-uri new-buffer)]
-    deps-uri))
-
 (defn maybe-create-workspace-config+ [create-joyride-dir?]
   (p/let [joyride-dir-exists?+ (utils/path-or-uri-exists?+ (path->uri (conf/workspace-abs-joyride-path) "."))]
     (when (or joyride-dir-exists?+ create-joyride-dir?)
       (p/let [deps-uri (path->uri (conf/workspace-abs-joyride-path) ["deps.edn"])
-              created?+ (maybe-create-content+ (getting-started-content-uri ["workspace" "deps.edn"])
-                                               deps-uri)]
-        (when created?+
-          (update-workspace-deps+ deps-uri))))))
+              _created?+ (maybe-create-content+ (getting-started-content-uri ["workspace" "deps.edn"])
+                                                deps-uri)]
+        deps-uri))))
 
 (defn create-and-open-content-file+ [source destination]
   (fn []


### PR DESCRIPTION
OK. So I was too trigger happy with adding Joyride user script config to the Joyride workspace deps.edn. Reverting that here and replacing with instructions on how to use the global/user deps.edn for this.

* Fixes #176

- [x] I have read the [developer documentation](https://github.com/BetterThanTomorrow/joyride/blob/master/CONTRIBUTE.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/BetterThanTomorrow/joyride/tree/master/vscode-test-runner/workspace-1/.joyride/src/integration_test) to prevent against future regressions

- [x] I have updated the **\[Unreleased\]** section of the [CHANGELOG.md](https://github.com/BetterThanTomorrow/joyride/blob/master/CHANGELOG.md) file with a link to the addressed issue.
