### PR TITLE
Make requiring utils from `cljs.repl` work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Joyride
 
 ## [Unreleased]
 
+- [Make requiring utils from `cljs.repl` work](https://github.com/BetterThanTomorrow/joyride/issues/188)
+
 ## [0.0.43] - 2024-02-12
 
 - Add uuid constructor to sci

--- a/deps.edn
+++ b/deps.edn
@@ -5,9 +5,9 @@
         org.babashka/sci
         #_{:local/root "../babashka/sci"}
         {:git/url "https://github.com/babashka/sci"
-         :git/sha "ad79a6c476affd1f8208efbfdba57992a68c8056"}
+         :git/sha "05eec0a37b3df3173a58372a5a05f7f22a4c3780"}
         org.babashka/sci.configs
         #_{:local/root "../sci.configs"}
         {:git/url "https://github.com/babashka/sci.configs"
-         :git/sha "3cd48a595bace287554b1735bb378bad1d22b931"}}
+         :git/sha "b87302d5569852ce4410271d089bc4cc3da7050a"}}
  :aliases {:dev {}}}

--- a/src/joyride/sci.cljs
+++ b/src/joyride/sci.cljs
@@ -4,6 +4,7 @@
    ["module" :as module]
    ["path" :as path]
    ["vscode" :as vscode]
+   clojure.repl
    [clojure.string :as str]
    [clojure.zip]
    [goog.object :as gobject]
@@ -99,6 +100,10 @@
 
 (def core-namespace (sci/create-ns 'clojure.core nil))
 
+(def cljreplns (sci/create-ns 'clojure.repl))
+(def clj-repl-namespace (merge (sci/copy-ns clojure.repl cljreplns)
+                                {'pst (fn [_] (throw (js/Error. "pst not yet implemented")))}))
+
 (def joyride-code
   {'*file* sci/file
    'extension-context (sci/copy-var db/extension-context joyride-ns)
@@ -117,6 +122,7 @@
                                         'remove-tap (sci/copy-var remove-tap core-namespace)
                                         'uuid (sci/copy-var uuid core-namespace)}
                          'clojure.zip zip-namespace
+                         'clojure.repl clj-repl-namespace
                          'cljs.test cljs-test-config/cljs-test-namespace
                          'cljs.pprint cljs-pprint-config/cljs-pprint-namespace
                          'promesa.core promesa-config/promesa-namespace

--- a/src/joyride/sci.cljs
+++ b/src/joyride/sci.cljs
@@ -124,7 +124,8 @@
                          'rewrite-clj.zip rewrite-clj-zip-ns
                          'rewrite-clj.parser rewrite-clj-parser-ns
                          'rewrite-clj.node rewrite-clj-node-ns}
-            :ns-aliases {'clojure.test 'cljs.test}
+            :ns-aliases '{clojure.test cljs.test
+                          clojure.repl cljs.repl}
             :load-fn (fn [{:keys [ns libname opts]}]
                        (cond
                          (symbol? libname)

--- a/src/joyride/sci.cljs
+++ b/src/joyride/sci.cljs
@@ -4,7 +4,6 @@
    ["module" :as module]
    ["path" :as path]
    ["vscode" :as vscode]
-   clojure.repl
    [clojure.string :as str]
    [clojure.zip]
    [goog.object :as gobject]
@@ -100,10 +99,6 @@
 
 (def core-namespace (sci/create-ns 'clojure.core nil))
 
-(def cljreplns (sci/create-ns 'clojure.repl))
-(def clj-repl-namespace (merge (sci/copy-ns clojure.repl cljreplns)
-                                {'pst (fn [_] (throw (js/Error. "pst not yet implemented")))}))
-
 (def joyride-code
   {'*file* sci/file
    'extension-context (sci/copy-var db/extension-context joyride-ns)
@@ -122,7 +117,7 @@
                                         'remove-tap (sci/copy-var remove-tap core-namespace)
                                         'uuid (sci/copy-var uuid core-namespace)}
                          'clojure.zip zip-namespace
-                         'clojure.repl clj-repl-namespace
+                         'clojure.repl {'pst (fn [_] (throw (js/Error. "pst not yet implemented")))}
                          'cljs.test cljs-test-config/cljs-test-namespace
                          'cljs.pprint cljs-pprint-config/cljs-pprint-namespace
                          'promesa.core promesa-config/promesa-namespace

--- a/src/joyride/sci.cljs
+++ b/src/joyride/sci.cljs
@@ -125,7 +125,7 @@
                          'rewrite-clj.parser rewrite-clj-parser-ns
                          'rewrite-clj.node rewrite-clj-node-ns}
             :ns-aliases '{clojure.test cljs.test
-                          clojure.repl cljs.repl}
+                          cljs.repl clojure.repl}
             :load-fn (fn [{:keys [ns libname opts]}]
                        (cond
                          (symbol? libname)

--- a/src/joyride/sci.cljs
+++ b/src/joyride/sci.cljs
@@ -99,6 +99,8 @@
 
 (def core-namespace (sci/create-ns 'clojure.core nil))
 
+(def pst-nyip (fn [_] (throw (js/Error. "pst not yet implemented"))))
+
 (def joyride-code
   {'*file* sci/file
    'extension-context (sci/copy-var db/extension-context joyride-ns)
@@ -117,7 +119,7 @@
                                         'remove-tap (sci/copy-var remove-tap core-namespace)
                                         'uuid (sci/copy-var uuid core-namespace)}
                          'clojure.zip zip-namespace
-                         'clojure.repl {'pst (fn [_] (throw (js/Error. "pst not yet implemented")))}
+                         'clojure.repl {'pst pst-nyip}
                          'cljs.test cljs-test-config/cljs-test-namespace
                          'cljs.pprint cljs-pprint-config/cljs-pprint-namespace
                          'promesa.core promesa-config/promesa-namespace


### PR DESCRIPTION
- Using `:ns-aliases` to alias `clojure.repl` as `cljs.repl`.
- Adding a `clojure.repl/pst` fn that throws a **not yet implemented** error. (Because SCI does not yet implement `pst` for `cljs`.

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/BetterThanTomorrow/joyride/blob/master/CONTRIBUTE.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/BetterThanTomorrow/joyride/tree/master/vscode-test-runner/workspace-1/.joyride/src/integration_test) to prevent against future regressions

- [x] I have updated the **\[Unreleased\]** section of the [CHANGELOG.md](https://github.com/BetterThanTomorrow/joyride/blob/master/CHANGELOG.md) file with a link to the addressed issue.

