### PR TITLE
Capture stdout for LM tool when waiting for promises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Joyride
 
 ## [Unreleased]
 
+- Fix: [The LM Tool is not capturing stdout, when waiting for promises](https://github.com/BetterThanTomorrow/joyride/issues/202)
+
 ## [0.0.49] - 2025-06-19
 
 - [Only create Joyride content on demand](https://github.com/BetterThanTomorrow/joyride/issues/200)


### PR DESCRIPTION
This is WIP, but improves things a lot so I'm going to release:

* Fixes #202 

- [x] I have read the [developer documentation](https://github.com/BetterThanTomorrow/joyride/blob/master/CONTRIBUTE.md).
- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
- [ ] This PR contains a [test](https://github.com/BetterThanTomorrow/joyride/tree/master/vscode-test-runner/workspace-1/.joyride/src/integration_test) to prevent against future regressions
- [x] I have updated the **\[Unreleased\]** section of the [CHANGELOG.md](https://github.com/BetterThanTomorrow/joyride/blob/master/CHANGELOG.md) file with a link to the addressed issue.
