### PR TITLE
Load-file-current-ns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Joyride
 
 ## [Unreleased]
 
+- [`load-file` changes namespace to that of the loaded file's](https://github.com/BetterThanTomorrow/joyride/issues/229)
+
 ## [0.0.59] - 2025-08-22
 
 - [Add `joyride.core/load-file` and `joyride.core/slurp`](https://github.com/BetterThanTomorrow/joyride/issues/226)

--- a/src/joyride/sci.cljs
+++ b/src/joyride/sci.cljs
@@ -122,10 +122,10 @@
     (p/let [source (slurp+ absolute-path)]
       (sci/binding [sci/ns @!last-ns]
         (sci/with-bindings {sci/file absolute-path}
-          (let [{:keys [ns val] :as result} (sci/eval-string+ (store/get-ctx) source)]
-            (println "BOOM! result" result ns val)
-            (vreset! !last-ns ns)
+          (let [{:keys [val]} (sci/eval-string+ (store/get-ctx) source)]
+            (vreset! !last-ns @sci/ns)
             val))))))
+
 (def joyride-code
   {'*file* sci/file
    'extension-context (sci/copy-var db/extension-context joyride-ns)

--- a/vscode-test-runner/workspace-1/.joyride/src/integration_test/joyride_core_test.cljs
+++ b/vscode-test-runner/workspace-1/.joyride/src/integration_test/joyride_core_test.cljs
@@ -70,6 +70,22 @@
       (is (= :load-file-success @(resolve 'test-data/test-symbol)))
       (is (= [1 2 3] (:vector @(resolve 'test-data/test-data)))))))
 
+(deftest-async load-file-should-not-change-ns
+  (testing "load-file should not change current *ns* (expected to fail until fixed)"
+    (let [before (str *ns*)]
+      (p/let [_ (joy/load-file "test_data.cljs")
+              after (str *ns*)]
+        (is (= before after) (str "Namespace changed from " before " to " after))
+        (is (= :load-file-success @(resolve 'test-data/test-symbol)))))))
+
+(deftest-async load-file-should-not-change-ns-across-evals
+  (testing "load-file should not persistently change *ns* across separate evals"
+    (let [before (str *ns*)]
+      (p/let [_ (joy/load-file "test_data.cljs")
+              reported-ns (vscode/commands.executeCommand "joyride.runCode" "(str *ns*)")]
+        (is (= before reported-ns)
+            (str "Namespace should not leak when loading a file: was " before ", now " reported-ns))))))
+
 (comment
   ;; TODO: Is this a bug?
   (= #js []

--- a/vscode-test-runner/workspace-1/.joyride/src/integration_test/joyride_core_test.cljs
+++ b/vscode-test-runner/workspace-1/.joyride/src/integration_test/joyride_core_test.cljs
@@ -70,24 +70,28 @@
       (is (= :load-file-success @(resolve 'test-data/test-symbol)))
       (is (= [1 2 3] (:vector @(resolve 'test-data/test-data)))))))
 
-(deftest-async load-file-should-not-change-ns
-  (testing "load-file should not change current *ns* (expected to fail until fixed)"
-    (let [before (str *ns*)]
-      (p/let [_ (joy/load-file "test_data.cljs")
-              after (str *ns*)]
-        (is (= before after) (str "Namespace changed from " before " to " after))
-        (is (= :load-file-success @(resolve 'test-data/test-symbol)))))))
 
-(deftest-async load-file-should-not-change-ns-across-evals
-  (testing "load-file should not persistently change *ns* across separate evals"
-    (let [before (str *ns*)]
-      (p/let [_ (joy/load-file "test_data.cljs")
-              reported-ns (vscode/commands.executeCommand "joyride.runCode" "(str *ns*)")]
-        (is (= before reported-ns)
-            (str "Namespace should not leak when loading a file: was " before ", now " reported-ns))))))
+;; These are tested manuallu in the repl to work: 2025-08-22 15:15
+
+;; This is probably not how to test this, even if the test actually passes
+#_(deftest-async load-file-should-not-change-ns
+    (testing "load-file should not change current *ns* (expected to fail until fixed)"
+      (let [before (str *ns*)]
+        (p/let [_ (joy/load-file "test_data.cljs")
+                after (str *ns*)]
+          (is (= before after) (str "Namespace shouldn't change, was: " before ", now: " after))
+          (is (= :load-file-success @(resolve 'test-data/test-symbol)))))))
+
+;; This fails because we can't properly await. May need a fully async sci environment?
+#_(deftest-async load-file-should-not-change-ns-across-evals
+    (testing "load-file should not persistently change *ns* across separate evals"
+      (let [before (str *ns*)]
+        (p/let [_ (joy/load-file "test_data.cljs")
+                reported-ns (vscode/commands.executeCommand "joyride.runCode" "(str *ns*)")]
+          (is (= before reported-ns)
+              (str "Namespace should not leak when loading a file: was: " before ", now: " reported-ns))))))
 
 (comment
   ;; TODO: Is this a bug?
   (= #js []
-     (js-properties))
-  )
+     (js-properties)))


### PR DESCRIPTION
Stop resetting the currrent namespace from that the loaded file.

* Fixes #229

No tests confirming, because I can't figure out how to test it. But I tested manually in the repl and left disabled tests that show my latest attempts. I think it may not be quite possible to test it with the test runner and current the current sci environment in Joyride?

- [x] I have read the [developer documentation](https://github.com/BetterThanTomorrow/joyride/blob/master/CONTRIBUTE.md).
- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
- [ ] This PR contains a [test](https://github.com/BetterThanTomorrow/joyride/tree/master/vscode-test-runner/workspace-1/.joyride/src/integration_test) to prevent against future regressions 
- [x] I have updated the **\[Unreleased\]** section of the [CHANGELOG.md](https://github.com/BetterThanTomorrow/joyride/blob/master/CHANGELOG.md) file with a link to the addressed issue.
