### PR TITLE
Fix nrepl close for vim-fireplace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Joyride
 
 ## [Unreleased]
 
+- [nREPL server: Implement `session-close` confirmation](https://github.com/BetterThanTomorrow/joyride/pull/233)
+
 ## [0.0.61] - 2025-08-22
 
 - Fix: [load-file is still tampering with current ns. (Issue #229 not fixed)](https://github.com/BetterThanTomorrow/joyride/issues/231)

--- a/src/joyride/nrepl.cljs
+++ b/src/joyride/nrepl.cljs
@@ -124,7 +124,7 @@
                     "status" ["done"]}))
 
 (defn handle-close [request send-fn]
-  (send-fn request {"status" ["done"]}))
+  (send-fn request {"status" ["done" "session-closed"]}))
 
 #_(defn handle-classpath [request send-fn]
     (send-fn


### PR DESCRIPTION
This issue fixes closing the session for clients like vim-fireplace that actively wait for "session-closed" in the reply.