### PR TITLE
Fix/handle non serializable results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Joyride
 
 ## [Unreleased]
 
+- Fix: [`Maximum call stack size exceeded` error when a script returns a non-serializable value, like a Promise.](https://github.com/BetterThanTomorrow/joyride/issues/218)
+
 ## [0.0.63] - 2025-09-08
 
 - [AI: Establish human language names for the tools](https://github.com/BetterThanTomorrow/joyride/pull/234)

--- a/vscode-test-runner/workspace-1/.joyride/src/integration_test/scripts_test.cljs
+++ b/vscode-test-runner/workspace-1/.joyride/src/integration_test/scripts_test.cljs
@@ -94,3 +94,9 @@
     (p/let [result (vscode/commands.executeCommand "joyride.runWorkspaceScript" "a_cljc_script.cljc")]
       (is (= :a-cljc-script
              result)))))
+
+(deftest-async run-a-non-serializable-return-value
+  (testing "Scripts returning a Promise should succeed without error"
+    (p/let [result (vscode/commands.executeCommand "joyride.runUserScript"
+                                                   "a_non_serializable_return_value.cljs")]
+      (is (nil? result) "The command should complete and return a safe value (nil)"))))


### PR DESCRIPTION
- Implements a `serializable?` check to prevent the script runner from returning complex objects like Promises or VS Code API objects.
- This prevents a '**Maximum call stack size exceeded**' error that would crash the extension host.
- Adds a regression test to confirm the fix and ensure simple values are still returned correctly.

Closes #218

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/BetterThanTomorrow/joyride/blob/master/CONTRIBUTE.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/BetterThanTomorrow/joyride/tree/master/vscode-test-runner/workspace-1/.joyride/src/integration_test) to prevent against future regressions

- [x] I have updated the **\[Unreleased\]** section of the [CHANGELOG.md](https://github.com/BetterThanTomorrow/joyride/blob/master/CHANGELOG.md) file with a link to the addressed issue.
