### PR TITLE
Prevent evaling autobalanced, potentially malindented code

### DIFF
--- a/.github/instructions/workflow.instructions.md
+++ b/.github/instructions/workflow.instructions.md
@@ -1,0 +1,37 @@
+---
+description: 'Workflows for this project'
+applyTo: '**'
+---
+
+## Joyride Project Issue Workflow
+
+Adopt a structured, REPL-driven approach for Joyride project issues to deliver high-quality, minimal changes with robust test coverage.
+
+### Pre-Implementation Phase
+1. **Explore via REPL**: Use the REPL to interactively understand current behavior and clarify the problem.
+2. **Establish criteria**: Define data-oriented, focused changes that address the core issue minimally.
+3. **Validate approach**: Confirm understanding and plan with the maintainer.
+4. **Branch creation**: Use `<issue-number>-descriptive-name` format (e.g., `247-remove-eval-autobalancing`).
+
+### Implementation Phase
+5. **Iterate in REPL**: Develop and test solutions interactively before file changes.
+6. **Apply minimal edits**: Implement the smallest change using structural editing tools for Clojure files.
+7. **Include tests**: Add integration tests in `vscode-test-runner/workspace-1/.joyride/src/integration_test/`.
+
+### PR Preparation Phase
+8. **Update CHANGELOG**: Add to `[Unreleased]` section:
+   ```markdown
+   - Fix: [Issue title](https://github.com/BetterThanTomorrow/joyride/issues/<number>)
+   ```
+9. **Verify tests**: Run `npm run integration-test` to ensure all pass.
+10. **Prepare PR**: Suggest description with checklist:
+    - ✓ Read developer docs (CONTRIBUTE.md)
+    - ✓ Addresses clear issue
+    - ✓ Includes regression tests
+    - ✓ Updated CHANGELOG
+
+### Key Principles
+- **REPL-first development**: Test solutions interactively to ensure reliability before file modifications.
+- **Minimal changes**: Focus on the smallest diff that resolves the issue effectively.
+- **Test coverage**: Require tests for every change to prevent regressions.
+- **Preserve history**: Avoid force pushes to maintain clear PR review trails.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Joyride
 ## [Unreleased]
 
 - [Provide instructions using the new VS Code API](https://github.com/BetterThanTomorrow/joyride/pull/245)
+- Fix: [The autobalancing of AI evaluations sometimes silently breaks the code](https://github.com/BetterThanTomorrow/joyride/issues/247)
 
 ## [0.0.65] - 2025-10-07
 

--- a/src/joyride/lm/eval/validation.cljs
+++ b/src/joyride/lm/eval/validation.cljs
@@ -1,0 +1,44 @@
+(ns joyride.lm.eval.validation
+  (:require [joyride.balance :as balance]))
+
+(defn validate-brackets
+  "Validates that code has balanced brackets without semantic changes.
+   Returns a map with :valid? boolean, optional :error string, optional :balanced-code,
+   and optional :parinfer-error map with structured error details.
+
+   Examples:
+   (validate-brackets \"(+ 1 2)\")
+   ;; => {:valid? true}
+
+   (validate-brackets \"(+ 1 2\")
+   ;; => {:valid? false
+   ;;     :error \"Code has unbalanced brackets...\"
+   ;;     :balanced-code \"(+ 1 2)\"}
+
+   (validate-brackets \"[(][]})]]\")
+   ;; => {:valid? false
+   ;;     :error \"Code has malformed brackets: Unmatched close-paren. Please fix...\"
+   ;;     :parinfer-error {:message \"Unmatched close-paren.\" :line 1 :column 2}}"
+  [code]
+  (let [inferred (balance/infer-parens code)
+        balanced-code (:text inferred)
+        balancing-occurred? (not= code balanced-code)]
+    (if balancing-occurred?
+      (if (:success inferred)
+        ;; Balancer succeeded but changed the code (ambiguous indentation)
+        {:valid? false
+         :error (str "Code has unbalanced brackets. The bracket balancer would change "
+                     "the code structure, which could alter its meaning. "
+                     "See the 'balanced-code' field for what the balancer would produce. "
+                     "If that looks correct, please re-evaluate using that code. "
+                     "Otherwise, fix the indentation and bracket balance before evaluation.")
+         :balanced-code balanced-code}
+        ;; Balancer failed (malformed brackets)
+        (let [error-info (:error inferred)]
+          {:valid? false
+           :error (str "Code has malformed brackets: " (:message error-info)
+                       " Please fix the bracket structure before evaluation.")
+           :parinfer-error {:message (:message error-info)
+                            :line (inc (:lineNo error-info))
+                            :column (:x error-info)}}))
+      {:valid? true})))

--- a/test/joyride/lm/eval/validation_test.cljs
+++ b/test/joyride/lm/eval/validation_test.cljs
@@ -1,0 +1,81 @@
+(ns joyride.lm.eval.validation-test
+  "Pure unit tests for bracket validation logic"
+  (:require [cljs.test :refer [deftest is testing]]
+            [clojure.string :as string]
+            [joyride.lm.eval.validation :as validation]))
+
+(deftest validate-brackets-balanced-code
+  (testing "Balanced code passes validation"
+    (let [result (validation/validate-brackets "(+ 1 2 3)")]
+      (is (:valid? result)
+          "Balanced code should be valid")
+      (is (nil? (:error result))
+          "No error for balanced code"))))
+
+(deftest validate-brackets-unbalanced-code
+  (testing "Unbalanced brackets fail validation with balanced code provided"
+    (let [result (validation/validate-brackets "(+ 1 2")]
+      (is (not (:valid? result))
+          "Unbalanced code should be invalid")
+      (is (string? (:error result))
+          "Error message should be present")
+      (is (string/includes? (:error result) "unbalanced brackets")
+          "Error message should mention unbalanced brackets")
+      (is (string/includes? (:error result) "balanced-code")
+          "Error should reference the balanced-code field")
+      (is (string/includes? (:error result) "re-evaluate using that code")
+          "Error should provide recovery guidance")
+      (is (= "(+ 1 2)" (:balanced-code result))
+          "Balanced code should be provided"))))
+
+(deftest validate-brackets-bad-indentation
+  (testing "Bad indentation that changes semantics fails validation with balanced code"
+    (let [code "(defn f [x]\n  {:foo 1\n  :bar 2})"
+          result (validation/validate-brackets code)]
+      (is (not (:valid? result))
+          "Semantically ambiguous code should be invalid")
+      (is (clojure.string/includes? (:error result) "bracket balancer would change")
+          "Error should explain semantic change risk")
+      (is (string? (:balanced-code result))
+          "Balanced code should be provided")
+      (is (clojure.string/includes? (:balanced-code result) "{:foo 1}")
+          "Balanced code should show the semantic transformation"))))
+
+(deftest validate-brackets-multiple-forms
+  (testing "Multiple balanced forms pass validation"
+    (let [code "(def x 1)\n(def y 2)\n(+ x y)"
+          result (validation/validate-brackets code)]
+      (is (:valid? result)
+          "Multiple balanced forms should be valid"))))
+
+(deftest validate-brackets-nested-structures
+  (testing "Nested balanced structures pass validation"
+    (let [code "{:foo {:bar {:baz 1}}}"
+          result (validation/validate-brackets code)]
+      (is (:valid? result)
+          "Nested structures should be valid when balanced"))))
+
+(deftest validate-brackets-malformed-code
+  (testing "Malformed brackets get parinfer error message"
+    (let [code "[(][]})]"
+          result (validation/validate-brackets code)]
+      (is (not (:valid? result))
+          "Malformed code should be invalid")
+      (is (string/includes? (:error result) "malformed brackets")
+          "Error should mention malformed brackets")
+      (is (string/includes? (:error result) "Unmatched close-paren")
+          "Error should include parinfer error message")
+      (is (nil? (:balanced-code result))
+          "Balanced code should NOT be provided for malformed code"))))
+
+(deftest validate-brackets-parinfer-error-structure
+  (let [malformed-code "[(][]})]"
+        result (validation/validate-brackets malformed-code)]
+    (testing "Malformed code returns structured parinfer error"
+      (is (false? (:valid? result)))
+      (is (string/includes? (:error result) "malformed brackets"))
+      (is (some? (:parinfer-error result)))
+      (is (= "Unmatched close-paren." (get-in result [:parinfer-error :message])))
+      (is (= 1 (get-in result [:parinfer-error :line])))
+      (is (= 2 (get-in result [:parinfer-error :column])))
+      (is (nil? (:balanced-code result))))))


### PR DESCRIPTION
* Fixes #247

- [x] I have read the [developer documentation](https://github.com/BetterThanTomorrow/joyride/blob/master/CONTRIBUTE.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/BetterThanTomorrow/joyride/tree/master/vscode-test-runner/workspace-1/.joyride/src/integration_test) to prevent against future regressions

- [x] I have updated the **\[Unreleased\]** section of the [CHANGELOG.md](https://github.com/BetterThanTomorrow/joyride/blob/master/CHANGELOG.md) file with a link to the addressed issue.
