### PR TITLE
263-limit-result-lengths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Joyride
 
 ## [Unreleased]
 
+- [AI: Restrict the depth and length of evaluation results returned to the agent](https://github.com/BetterThanTomorrow/joyride/pull/263)
+
 ## [0.0.71] - 2025-11-02
 
 - Fix: [Hitting maximum stack size error when Evaluating Selection](https://github.com/BetterThanTomorrow/joyride/pull/218) (Works around a yet unfigured-out Promesa issue.)

--- a/package.json
+++ b/package.json
@@ -65,6 +65,16 @@
             "type": "boolean",
             "default": true,
             "description": "Enable Copilot Joyride REPL access"
+          },
+          "joyride.lm.evaluationResultsMaxLength": {
+            "type": "number",
+            "default": 25,
+            "markdownDescription": "Maximum number of items in collections returned to the agent during REPL evaluation. Use `0` to disable length limiting."
+          },
+          "joyride.lm.evaluationResultsMaxDepth": {
+            "type": "number",
+            "default": 7,
+            "markdownDescription": "Maximum nesting depth for evaluation results returned to the agent; deeper structures are replaced with `##`. Use `0` to disable depth limiting."
           }
         }
       }

--- a/src/joyride/lm/evaluation.cljs
+++ b/src/joyride/lm/evaluation.cljs
@@ -55,9 +55,13 @@
                                                 :toString (str result)}
                                                result)
                                 zprint-opts (cond-> {:width 10000}
-                                              (and max-length (not (zero? max-length)))
+                                              (and max-length
+                                                   (number? max-length)
+                                                   (not (zero? max-length)))
                                               (assoc :max-length max-length)
-                                              (and max-depth (not (zero? max-depth)))
+                                              (and max-depth
+                                                   (number? max-depth)
+                                                   (not (zero? max-depth)))
                                               (assoc :max-depth max-depth))
                                 limited-result-str (zp/zprint-str result-value zprint-opts)]
                             {:result limited-result-str

--- a/src/joyride/lm/evaluation.cljs
+++ b/src/joyride/lm/evaluation.cljs
@@ -8,7 +8,8 @@
    [joyride.sci :as joyride-sci]
    [promesa.core :as p]
    [sci.core :as sci]
-   [sci.ctx-store :as store]))
+   [sci.ctx-store :as store]
+   [zprint.core :as zp]))
 
 (defn- get-eval-config []
   (let [config (vscode/workspace.getConfiguration "joyride.lm")]
@@ -53,11 +54,12 @@
                                                 :message "Promise returned but not awaited (fire-and-forget mode)"
                                                 :toString (str result)}
                                                result)
-                                effective-length (when-not (zero? max-length) max-length)
-                                effective-depth (when-not (zero? max-depth) max-depth)
-                                limited-result-str (binding [*print-length* effective-length
-                                                             *print-level* effective-depth]
-                                                     (pr-str result-value))]
+                                zprint-opts (cond-> {:width 10000}
+                                              (and max-length (not (zero? max-length)))
+                                              (assoc :max-length max-length)
+                                              (and max-depth (not (zero? max-depth)))
+                                              (assoc :max-depth max-depth))
+                                limited-result-str (zp/zprint-str result-value zprint-opts)]
                             {:result limited-result-str
                              :error error
                              :ns (str @sci/ns)


### PR DESCRIPTION
Using zprint to limit length of lm evaluation results

* Fixing: #263

- [x] I have read the [developer documentation](https://github.com/BetterThanTomorrow/joyride/blob/master/CONTRIBUTE.md).
- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
- [ ] This PR contains a [test](https://github.com/BetterThanTomorrow/joyride/tree/master/vscode-test-runner/workspace-1/.joyride/src/integration_test) to prevent against future regressions
- [x] I have updated the **\[Unreleased\]** section of the [CHANGELOG.md](https://github.com/BetterThanTomorrow/joyride/blob/master/CHANGELOG.md) file with a link to the addressed issue.
